### PR TITLE
Optional commit SHA and app version build arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,11 @@ COPY --chown=node:node --from=build /home/node/app/dist .
 COPY --chown=node:node --from=build /home/node/app/prisma prisma
 COPY --chown=node:node --from=build /home/node/app/prod_node_modules node_modules
 
+ARG GIT_COMMIT_SHA=""
+ARG APP_VERSION=""
+
+ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
+ENV APP_VERSION=${APP_VERSION}
 ENV NODE_ENV=production
 ENV NODE_PATH=.
 


### PR DESCRIPTION
Example of setting these variables during build time:
```$
$ docker build --build-arg APP_VERSION=$(date "+%Y%m%d%H%M") --build-arg=GIT_COMMIT_SHA=$(git rev-parse --short HEAD) -t my-service:latest .
```