### PR TITLE
Made `mysql`, `redis` and `rabbitmq` service ports configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   mysql:
     image: mysql:8.0.28-oracle
     ports:
-      - 3306:3306
+      - ${DOCKER_MYSQL_PORT:-3306}:3306
     volumes:
       - mysql_data:/var/lib/mysql
     environment:
@@ -26,15 +26,15 @@ services:
     image: redis:6.2.7-alpine
     command: redis-server --requirepass sOmE_sEcUrE_pAsS
     ports:
-      - 6379:6379
+      - ${DOCKER_REDIS_PORT:-6379}:6379
     volumes:
       - redis_data:/redis/data:cached
 
   rabbitmq:
     image: rabbitmq:3.11.5
     ports:
-      - 5672:5672
-      - 15672:15672
+      - ${DOCKER_RABBITMQ_CLIENT_PORT:-5672}:5672
+      - ${DOCKER_RABBITMQ_MANAGEMENT_PORT:-15672}:15672
     volumes:
       - rabbit_data:/var/lib/rabbitmq
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -53,3 +53,10 @@ In production you are expected to set environment variables during deployment (e
 
 - (OPTIONAL) `BUGSNAG_KEY` - BugSnag API key
 - (OPTIONAL) `BUGSNAG_ENABLED` - whether to send errors to BugSnag (`true`)
+
+### docker compose
+
+- (OPTIONAL) `DOCKER_MYSQL_PORT` - Docker `mysql` service port, for development purposes only (`3306`)
+- (OPTIONAL) `DOCKER_REDIS_PORT` - Docker `redis` service port, for development purposes only (`6379`)
+- (OPTIONAL) `DOCKER_RABBITMQ_CLIENT_PORT` - Docker `rabbitmq` service client port, for development purposes only (`5672`)
+- (OPTIONAL) `DOCKER_RABBITMQ_MANAGEMENT_PORT` - Docker `rabbitmq` service management port, for development purposes only (`15672`)


### PR DESCRIPTION
Very good for local development, used [variable substitution](https://docs.docker.com/compose/compose-file/compose-file-v3/#variable-substitution) in docker-compose.yml.