### PR TITLE
Passing `appConfig.appVersion` to bugsnag configuration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -239,6 +239,7 @@ export async function getApp(
     bugsnag: {
       apiKey: config.vendors.bugsnag.apiKey ?? '',
       releaseStage: appConfig.appEnv,
+      appVersion: appConfig.appVersion,
     },
   })
   await app.register(prismaOtelTracingPlugin, {


### PR DESCRIPTION
As the title says.
It was already tested on an existing service.