### PR TITLE
Example of config overrides in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "pino-pretty": "^10.2.0",
         "redis-semaphore": "^5.5.0",
         "toad-scheduler": "^3.0.0",
+        "ts-deepmerge": "^6.2.0",
         "undici": "^5.24.0",
         "validation-utils": "^9.1.0",
         "zod": "^3.22.2"
@@ -11511,6 +11512,14 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-deepmerge": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-6.2.0.tgz",
+      "integrity": "sha512-2qxI/FZVDPbzh63GwWIZYE7daWKtwXZYuyc8YNq0iTmMUwn4mL0jRLsp6hfFlgbdRSR4x2ppe+E86FnvEpN7Nw==",
+      "engines": {
+        "node": ">=14.13.1"
       }
     },
     "node_modules/ts-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "pino-pretty": "^10.2.0",
         "redis-semaphore": "^5.5.0",
         "toad-scheduler": "^3.0.0",
-        "ts-deepmerge": "^6.2.0",
         "undici": "^5.24.0",
         "validation-utils": "^9.1.0",
         "zod": "^3.22.2"
@@ -67,6 +66,7 @@
         "oas-validator": "^5.0.8",
         "prettier": "^3.0.3",
         "prisma": "^5.2.0",
+        "ts-deepmerge": "^6.2.0",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "5.2.2",
@@ -11518,6 +11518,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-6.2.0.tgz",
       "integrity": "sha512-2qxI/FZVDPbzh63GwWIZYE7daWKtwXZYuyc8YNq0iTmMUwn4mL0jRLsp6hfFlgbdRSR4x2ppe+E86FnvEpN7Nw==",
+      "dev": true,
       "engines": {
         "node": ">=14.13.1"
       }

--- a/package.json
+++ b/package.json
@@ -64,15 +64,16 @@
     "pino-pretty": "^10.2.0",
     "redis-semaphore": "^5.5.0",
     "toad-scheduler": "^3.0.0",
+    "ts-deepmerge": "^6.2.0",
     "undici": "^5.24.0",
     "validation-utils": "^9.1.0",
     "zod": "^3.22.2"
   },
   "devDependencies": {
+    "@amplitude/analytics-types": "^2.1.2",
     "@types/amqplib": "^0.10.1",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/newrelic": "^9.14.0",
-    "@amplitude/analytics-types": "^2.1.2",
     "@types/node": "^20.6.0",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "@typescript-eslint/parser": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "pino-pretty": "^10.2.0",
     "redis-semaphore": "^5.5.0",
     "toad-scheduler": "^3.0.0",
-    "ts-deepmerge": "^6.2.0",
     "undici": "^5.24.0",
     "validation-utils": "^9.1.0",
     "zod": "^3.22.2"
@@ -89,6 +88,7 @@
     "oas-validator": "^5.0.8",
     "prettier": "^3.0.3",
     "prisma": "^5.2.0",
+    "ts-deepmerge": "^6.2.0",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "5.2.2",

--- a/src/app.e2e.test.ts
+++ b/src/app.e2e.test.ts
@@ -77,8 +77,9 @@ describe('app', () => {
         config = testContext.diContainer.cradle.config
       })
       it('resolves to default value', () => {
-        expect(config.iAmHereForTestingConfigOverrideInTests.firstValue).toBe(true)
-        expect(config.iAmHereForTestingConfigOverrideInTests.secondValue).toBe(true)
+        expect(config.vendors.amplitude.isEnabled).toBe(false)
+        expect(config.vendors.amplitude.serverZone).toBe('EU')
+        expect(config.vendors.amplitude.flushIntervalMillis).toBe(10000)
       })
     })
 
@@ -86,15 +87,13 @@ describe('app', () => {
       let testContext: TestContext
       let config: Config
       beforeEach(() => {
-        testContext = createTestContext(
-          {},
-          { iAmHereForTestingConfigOverrideInTests: { firstValue: false } },
-        )
+        testContext = createTestContext({}, { vendors: { amplitude: { serverZone: 'US' } } })
         config = testContext.diContainer.cradle.config
       })
       it('resolves to override value', () => {
-        expect(config.iAmHereForTestingConfigOverrideInTests.firstValue).toBe(false)
-        expect(config.iAmHereForTestingConfigOverrideInTests.secondValue).toBe(true)
+        expect(config.vendors.amplitude.isEnabled).toBe(false)
+        expect(config.vendors.amplitude.serverZone).toBe('US')
+        expect(config.vendors.amplitude.flushIntervalMillis).toBe(10000)
       })
     })
   })

--- a/src/app.e2e.test.ts
+++ b/src/app.e2e.test.ts
@@ -70,12 +70,13 @@ describe('app', () => {
 
   describe('config overrides in tests', () => {
     describe('when not overwritten', () => {
-      let testContext: TestContext
       let config: Config
+
       beforeEach(() => {
-        testContext = createTestContext({}, {})
+        const testContext = createTestContext({}, {})
         config = testContext.diContainer.cradle.config
       })
+
       it('resolves to default value', () => {
         expect(config.vendors.amplitude.isEnabled).toBe(false)
         expect(config.vendors.amplitude.serverZone).toBe('EU')
@@ -84,12 +85,13 @@ describe('app', () => {
     })
 
     describe('when overwritten', () => {
-      let testContext: TestContext
       let config: Config
+
       beforeEach(() => {
-        testContext = createTestContext({}, { vendors: { amplitude: { serverZone: 'US' } } })
+        const testContext = createTestContext({}, { vendors: { amplitude: { serverZone: 'US' } } })
         config = testContext.diContainer.cradle.config
       })
+
       it('resolves to override value', () => {
         expect(config.vendors.amplitude.isEnabled).toBe(false)
         expect(config.vendors.amplitude.serverZone).toBe('US')

--- a/src/app.e2e.test.ts
+++ b/src/app.e2e.test.ts
@@ -1,9 +1,11 @@
 import { buildClient, sendGet } from '@lokalise/node-core'
 import type { FastifyInstance } from 'fastify'
 
+import type { TestContext } from '../test/TestContext'
+import { createTestContext } from '../test/TestContext'
+
 import { getApp } from './app'
-import { TestContext, createTestContext } from 'test/TestContext'
-import { Config } from './infrastructure/config'
+import type { Config } from './infrastructure/config'
 
 describe('app', () => {
   let app: FastifyInstance

--- a/src/app.e2e.test.ts
+++ b/src/app.e2e.test.ts
@@ -2,6 +2,8 @@ import { buildClient, sendGet } from '@lokalise/node-core'
 import type { FastifyInstance } from 'fastify'
 
 import { getApp } from './app'
+import { TestContext, createTestContext } from 'test/TestContext'
+import { Config } from './infrastructure/config'
 
 describe('app', () => {
   let app: FastifyInstance
@@ -61,6 +63,37 @@ describe('app', () => {
       const response = await app.inject().get('/documentation/static/index.html').end()
 
       expect(response.statusCode).toBe(200)
+    })
+  })
+
+  describe('config overrides in tests', () => {
+    describe('when not overwritten', () => {
+      let testContext: TestContext
+      let config: Config
+      beforeEach(() => {
+        testContext = createTestContext({}, {})
+        config = testContext.diContainer.cradle.config
+      })
+      it('resolves to default value', () => {
+        expect(config.iAmHereForTestingConfigOverrideInTests.firstValue).toBe(true)
+        expect(config.iAmHereForTestingConfigOverrideInTests.secondValue).toBe(true)
+      })
+    })
+
+    describe('when overwritten', () => {
+      let testContext: TestContext
+      let config: Config
+      beforeEach(() => {
+        testContext = createTestContext(
+          {},
+          { iAmHereForTestingConfigOverrideInTests: { firstValue: false } },
+        )
+        config = testContext.diContainer.cradle.config
+      })
+      it('resolves to override value', () => {
+        expect(config.iAmHereForTestingConfigOverrideInTests.firstValue).toBe(false)
+        expect(config.iAmHereForTestingConfigOverrideInTests.secondValue).toBe(true)
+      })
     })
   })
 })

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -4,12 +4,6 @@ import type { RedisConfig } from '@lokalise/node-core'
 const configScope: ConfigScope = new ConfigScope()
 const redisDbValidator = createRangeValidator(0, 15)
 
-type NestedPartial<T> = {
-  [P in keyof T]?: NestedPartial<T[P]>
-}
-
-export type ConfigOverrides = NestedPartial<Config>
-
 export type IntervalJobConfig = {
   periodInSeconds: number
 }

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -13,10 +13,6 @@ export type CronJobConfig = {
 }
 
 export type Config = {
-  iAmHereForTestingConfigOverrideInTests: {
-    firstValue: boolean
-    secondValue: boolean
-  }
   db: DbConfig
   redis: RedisConfig
   scheduler: RedisConfig
@@ -84,10 +80,6 @@ export type AppConfig = {
 
 export function getConfig(): Config {
   return {
-    iAmHereForTestingConfigOverrideInTests: {
-      firstValue: true,
-      secondValue: true,
-    },
     app: getAppConfig(),
     db: getDbConfig(),
     redis: getRedisConfig(),

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -4,6 +4,12 @@ import type { RedisConfig } from '@lokalise/node-core'
 const configScope: ConfigScope = new ConfigScope()
 const redisDbValidator = createRangeValidator(0, 15)
 
+type NestedPartial<T> = {
+  [P in keyof T]?: NestedPartial<T[P]>
+}
+
+export type ConfigOverrides = NestedPartial<Config>
+
 export type IntervalJobConfig = {
   periodInSeconds: number
 }
@@ -13,6 +19,10 @@ export type CronJobConfig = {
 }
 
 export type Config = {
+  iAmHereForTestingConfigOverrideInTests: {
+    firstValue: boolean
+    secondValue: boolean
+  }
   db: DbConfig
   redis: RedisConfig
   scheduler: RedisConfig
@@ -80,6 +90,10 @@ export type AppConfig = {
 
 export function getConfig(): Config {
   return {
+    iAmHereForTestingConfigOverrideInTests: {
+      firstValue: true,
+      secondValue: true,
+    },
     app: getAppConfig(),
     db: getDbConfig(),
     redis: getRedisConfig(),

--- a/test/TestContext.ts
+++ b/test/TestContext.ts
@@ -6,9 +6,16 @@ import { asFunction, createContainer } from 'awilix'
 import type { FastifyInstance } from 'fastify'
 import merge from 'ts-deepmerge'
 
-import { getConfig, type ConfigOverrides } from '../src/infrastructure/config'
+import type { Config } from '../src/infrastructure/config'
+import { getConfig } from '../src/infrastructure/config'
 import type { DependencyOverrides } from '../src/infrastructure/diConfig'
 import { registerDependencies } from '../src/infrastructure/diConfig'
+
+type NestedPartial<T> = {
+  [P in keyof T]?: NestedPartial<T[P]>
+}
+
+export type ConfigOverrides = NestedPartial<Config>
 
 export type TestContext = {
   diContainer: AwilixContainer<Cradle>

--- a/test/TestContext.ts
+++ b/test/TestContext.ts
@@ -2,9 +2,11 @@ import type { Cradle } from '@fastify/awilix'
 import { NewRelicTransactionManager } from '@lokalise/fastify-extras'
 import { globalLogger } from '@lokalise/node-core'
 import type { AwilixContainer } from 'awilix'
-import { createContainer } from 'awilix'
+import { asFunction, createContainer } from 'awilix'
 import type { FastifyInstance } from 'fastify'
+import merge from 'ts-deepmerge'
 
+import { getConfig, type ConfigOverrides } from '../src/infrastructure/config'
 import type { DependencyOverrides } from '../src/infrastructure/diConfig'
 import { registerDependencies } from '../src/infrastructure/diConfig'
 
@@ -12,20 +14,32 @@ export type TestContext = {
   diContainer: AwilixContainer<Cradle>
 }
 
-export function createTestContext(dependencyOverrides: DependencyOverrides = {}): TestContext {
+export function createTestContext(
+  dependencyOverrides: DependencyOverrides = {},
+  configOVerrides: ConfigOverrides = {},
+): TestContext {
   const diContainer = createContainer({
     injectionMode: 'PROXY',
   })
+
   const fakeApp: Partial<FastifyInstance> = {
     newrelicTransactionManager: new NewRelicTransactionManager(false),
   }
+
+  const dependencies = {
+    ...dependencyOverrides,
+    config: asFunction(() => {
+      return merge(getConfig(), configOVerrides)
+    }),
+  }
+
   registerDependencies(
     diContainer,
     {
       app: fakeApp as FastifyInstance,
       logger: globalLogger,
     },
-    dependencyOverrides,
+    dependencies,
   )
 
   return {

--- a/test/TestContext.ts
+++ b/test/TestContext.ts
@@ -9,7 +9,7 @@ import merge from 'ts-deepmerge'
 import type { Config } from '../src/infrastructure/config'
 import { getConfig } from '../src/infrastructure/config'
 import type { DependencyOverrides } from '../src/infrastructure/diConfig'
-import { registerDependencies } from '../src/infrastructure/diConfig'
+import { SINGLETON_CONFIG, registerDependencies } from '../src/infrastructure/diConfig'
 
 type NestedPartial<T> = {
   [P in keyof T]?: NestedPartial<T[P]>
@@ -38,7 +38,7 @@ export function createTestContext(
         ...dependencyOverrides,
         config: asFunction(() => {
           return merge(getConfig(), configOverrides)
-        }),
+        }, SINGLETON_CONFIG),
       }
     : dependencyOverrides
 

--- a/test/TestContext.ts
+++ b/test/TestContext.ts
@@ -23,7 +23,7 @@ export type TestContext = {
 
 export function createTestContext(
   dependencyOverrides: DependencyOverrides = {},
-  configOverrides: ConfigOverrides,
+  configOverrides?: ConfigOverrides,
 ): TestContext {
   const diContainer = createContainer({
     injectionMode: 'PROXY',

--- a/test/TestContext.ts
+++ b/test/TestContext.ts
@@ -23,7 +23,7 @@ export type TestContext = {
 
 export function createTestContext(
   dependencyOverrides: DependencyOverrides = {},
-  configOVerrides: ConfigOverrides = {},
+  configOverrides: ConfigOverrides,
 ): TestContext {
   const diContainer = createContainer({
     injectionMode: 'PROXY',
@@ -33,12 +33,14 @@ export function createTestContext(
     newrelicTransactionManager: new NewRelicTransactionManager(false),
   }
 
-  const dependencies = {
-    ...dependencyOverrides,
-    config: asFunction(() => {
-      return merge(getConfig(), configOVerrides)
-    }),
-  }
+  const dependencies = configOverrides
+    ? {
+        ...dependencyOverrides,
+        config: asFunction(() => {
+          return merge(getConfig(), configOverrides)
+        }),
+      }
+    : dependencyOverrides
 
   registerDependencies(
     diContainer,


### PR DESCRIPTION
Using `ts-deepmerge` in `createTestContext()` we can now expose a way of doing partial overwrites of config values during testing.

These are the steps required to copy this behavior:

1. Install `ts-deepmerge` package
2. Adopt the changes to `TestContext.ts` from this PR
3. Happy coding ✌️ 