### PR TITLE
Remove Redis log noise

### DIFF
--- a/src/infrastructure/commonDiConfig.ts
+++ b/src/infrastructure/commonDiConfig.ts
@@ -60,11 +60,7 @@ export function resolveCommonDiConfig(
       {
         dispose: (redis) => {
           return new Promise((resolve) => {
-            void redis.quit((err, result) => {
-              if (err) {
-                globalLogger.error(`Error while closing redis: ${err.message}`)
-                return resolve(err)
-              }
+            void redis.quit((_err, result) => {
               return resolve(result)
             })
           })
@@ -91,11 +87,7 @@ export function resolveCommonDiConfig(
       {
         dispose: (redis) => {
           return new Promise((resolve) => {
-            void redis.quit((err, result) => {
-              if (err) {
-                globalLogger.error(`Error while closing redis: ${err.message}`)
-                return resolve(err)
-              }
+            void redis.quit((_err, result) => {
               return resolve(result)
             })
           })
@@ -122,11 +114,7 @@ export function resolveCommonDiConfig(
       {
         dispose: (redis) => {
           return new Promise((resolve) => {
-            void redis.quit((err, result) => {
-              if (err) {
-                globalLogger.error(`Error while closing redis: ${err.message}`)
-                return resolve(err)
-              }
+            void redis.quit((_err, result) => {
               return resolve(result)
             })
           })


### PR DESCRIPTION
We don't really care if there is an error closing Redis connection, not much we can do about it, nor is it particularly important (usually it just complains if connection was already closed, which is fine)