### PR TITLE
feature: disable BullMQ worker in CLI mode

### DIFF
--- a/scripts/utils/cliCommandWrapper.ts
+++ b/scripts/utils/cliCommandWrapper.ts
@@ -31,6 +31,9 @@ export const cliCommandWrapper = async <ArgsSchema extends z.Schema | undefined>
     jobsEnabled: false,
     healthchecksEnabled: false,
     monitoringEnabled: false,
+    app: {
+      cliMode: true,
+    },
   })
 
   const requestId = generateMonotonicUuid()

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -83,6 +83,7 @@ export type AppConfig = {
   metrics: {
     isEnabled: boolean
   }
+  cliMode: boolean
 }
 
 export function getConfig(): Config {
@@ -205,6 +206,7 @@ export function getAppConfig(): AppConfig {
     metrics: {
       isEnabled: configScope.getOptionalBoolean('METRICS_ENABLED', !configScope.isDevelopment()),
     },
+    cliMode: false, // If a different value is needed, it should be passed to the app directly
   }
 }
 

--- a/src/infrastructure/jobs/AbstractEnqueuedJobProcessor.spec.ts
+++ b/src/infrastructure/jobs/AbstractEnqueuedJobProcessor.spec.ts
@@ -1,0 +1,113 @@
+import type { BaseJobPayload } from '@lokalise/background-jobs-common'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { cleanRedis } from '../../../test/RedisCleaner.js'
+import {
+  type TestContext,
+  createTestContext,
+  destroyTestContext,
+} from '../../../test/TestContext.js'
+import { AbstractEnqueuedJobProcessor } from './AbstractEnqueuedJobProcessor.js'
+
+const TEST_QUEUE = 'dummy_queue'
+
+class TestJobProcessor extends AbstractEnqueuedJobProcessor<BaseJobPayload> {
+  protected async execute() {
+    // Mock implementation
+  }
+
+  protected async process() {
+    // Mock implementation
+  }
+}
+
+describe('AbstractEnqueuedJobProcessor', () => {
+  let testContext: TestContext
+
+  describe('Default mode', () => {
+    beforeAll(async () => {
+      testContext = await createTestContext()
+    })
+
+    beforeEach(async () => {
+      await cleanRedis(testContext.diContainer.cradle.redis)
+    })
+
+    afterAll(async () => {
+      await destroyTestContext(testContext)
+    })
+
+    it('should start queue and worker', async () => {
+      // @ts-ignore using protected constructor for testing purposes
+      const processor = new TestJobProcessor(testContext.diContainer.cradle, {
+        queueId: TEST_QUEUE,
+        queueOptions: {},
+        workerOptions: {},
+      })
+      await processor.start()
+
+      // Worker is instantiated and running
+      expect(processor.worker.isRunning()).toBeTruthy()
+
+      const jobData = {
+        id: 'test_id',
+        value: 'test',
+        metadata: { correlationId: 'correlation_id' },
+      }
+      const jobId = await processor.schedule(jobData)
+
+      // Job is added to the queue and processed by the worker
+      const spyResult = await processor.spy.waitForJobWithId(jobId, 'completed')
+      expect(spyResult.data).toMatchObject(jobData)
+
+      await processor.dispose()
+    })
+  })
+
+  describe('CLI mode enabled', () => {
+    beforeAll(async () => {
+      testContext = await createTestContext(
+        {},
+        {},
+        {
+          app: {
+            cliMode: true,
+          },
+        },
+      )
+    })
+
+    beforeEach(async () => {
+      await cleanRedis(testContext.diContainer.cradle.redis)
+    })
+
+    afterAll(async () => {
+      await destroyTestContext(testContext)
+    })
+
+    it('should start queue but not worker', async () => {
+      // @ts-ignore using protected constructor for testing purposes
+      const processor = new TestJobProcessor(testContext.diContainer.cradle, {
+        queueId: TEST_QUEUE,
+        queueOptions: {},
+        workerOptions: {},
+      })
+      await processor.start()
+
+      // Worker is instantiated but not running
+      expect(processor.worker.isRunning()).toBeFalsy()
+
+      const jobData = {
+        id: 'test_id',
+        value: 'test',
+        metadata: { correlationId: 'correlation_id' },
+      }
+      const jobId = await processor.schedule(jobData)
+
+      // Job is added to the queue but not processed by the worker
+      const spyResult = await processor.spy.waitForJobWithId(jobId, 'scheduled')
+      expect(spyResult.data).toMatchObject(jobData)
+
+      await processor.dispose()
+    })
+  })
+})

--- a/src/infrastructure/jobs/AbstractEnqueuedJobProcessor.ts
+++ b/src/infrastructure/jobs/AbstractEnqueuedJobProcessor.ts
@@ -27,6 +27,13 @@ export abstract class AbstractEnqueuedJobProcessor<
         queueId: config.queueId,
         queueOptions: config.queueOptions,
         workerOptions: config.workerOptions,
+        /**
+         * autorun allows to decide when to start a worker. While we normally want it to always be running,
+         * in case of CLI commands it is advisable to not start it so that within the script we can add new jobs to
+         * the queue, but they (and existing jobs) will not be processed by the app instance created within the command.
+         * Processing will only be done by the live instance of the application, which is always running.
+         */
+        workerAutoRunEnabled: !dependencies.config.app.cliMode,
         redisConfig: dependencies.config.redis,
       },
     )


### PR DESCRIPTION
There are different scenarios where we would like to schedule or unschedule a BullMQ repeatable job through a CLI command. While it is definitely possible to set up the app to do so, it might happen that:
- Other jobs might be processed by the CLI instance while it is up, rather than the production application;
- In case of scheduling a job, it might be executed by the CLI instance rather than the production application.

This solution will start the queue, but not the worker, when instantiating the app from a CLI command, allowing for jobs to be added to/removed from the queue but not being processed by the app instance created within the CLI command. This is achieved with a combination of a new parameter in the `AbstractBackgroundJobProcessor` constructor to disable the worker and a new config value that is set in the CLI context to understand the app was instantiated within a CLI command.