### PR TITLE
Specify migrations schema explicitly

### DIFF
--- a/src/db/drizzle.config.ts
+++ b/src/db/drizzle.config.ts
@@ -13,4 +13,7 @@ export default defineConfig({
   dbCredentials: {
     url: config.db.databaseUrl,
   },
+  migrations: {
+    schema: 'migrations', // adjust if you want to have per-service migration schemas
+  },
 })


### PR DESCRIPTION
This is related to Platform requirement to avoid using `public` schema for storing migrations.

Since service can use multiple schemas (when there are isolated modules in it), used a generic `migrations` one.