### PR TITLE
Restore original zod schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "fastify-graceful-shutdown": "^4.0.1",
                 "fastify-metrics": "^12.1.0",
                 "fastify-no-icon": "^7.0.0",
-                "fastify-type-provider-zod": "^5.0.1",
+                "fastify-type-provider-zod": "^5.0.2",
                 "ioredis": "^5.6.1",
                 "jsonwebtoken": "^9.0.2",
                 "layered-loader": "^14.0.1",
@@ -3951,9 +3951,9 @@
             }
         },
         "node_modules/@fastify/error": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.1.0.tgz",
-            "integrity": "sha512-KeFcciOr1eo/YvIXHP65S94jfEEqn1RxTRBT1aJaHxY5FK0/GDXYozsQMMWlZoHgi8i0s+YtrLsgj/JkUUjSkQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+            "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
             "funding": [
                 {
                     "type": "github",
@@ -8957,17 +8957,17 @@
             "license": "MIT"
         },
         "node_modules/fastify-type-provider-zod": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/fastify-type-provider-zod/-/fastify-type-provider-zod-5.0.1.tgz",
-            "integrity": "sha512-h2XEUakE8WCfL/Qnd0VcF1NcpKtCx7XvK8Mz0VclwSksNDpu0ggJt80HMg9oOUm/wOcfxojndBrq0QKnhyVp5A==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/fastify-type-provider-zod/-/fastify-type-provider-zod-5.0.2.tgz",
+            "integrity": "sha512-myolKCxze2rx25Ia88Erb4TZpFIUWyCUqMDgNqE6KQnXoERXwMCPuwfj/1zKkVBlu5dvLo1c/H7GneZUhOWXiw==",
             "license": "MIT",
             "dependencies": {
-                "@fastify/error": "^4.1.0"
+                "@fastify/error": "^4.2.0"
             },
             "peerDependencies": {
                 "@fastify/swagger": ">=9.5.1",
                 "fastify": "^5.0.0",
-                "zod": ">=3.25.56"
+                "zod": ">=3.25.67"
             }
         },
         "node_modules/fastparallel": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "fastify-graceful-shutdown": "^4.0.1",
         "fastify-metrics": "^12.1.0",
         "fastify-no-icon": "^7.0.0",
-        "fastify-type-provider-zod": "^5.0.1",
+        "fastify-type-provider-zod": "^5.0.2",
         "ioredis": "^5.6.1",
         "jsonwebtoken": "^9.0.2",
         "layered-loader": "^14.0.1",

--- a/src/modules/users/schemas/userSchemas.ts
+++ b/src/modules/users/schemas/userSchemas.ts
@@ -10,7 +10,7 @@ export const USER_SCHEMA = z.object({
 
 export const CREATE_USER_BODY_SCHEMA = z.object({
   name: z.string(),
-  age: z.number().optional(), // Remove nullable to fix OpenAPI generation
+  age: z.optional(z.nullable(z.preprocess(toNumberPreprocessor, z.number()))),
   email: z.email(),
 })
 


### PR DESCRIPTION
This restores the more complicated zod schema that we used prior to migration to zod v4

Context:

https://github.com/turkerdev/fastify-type-provider-zod/pull/189
https://github.com/colinhacks/zod/pull/4811

tl;dr -> zod broke compatibility with OpenAPI 3.0