### PR TITLE
Switch to a more modern spec validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
                 "@lokalise/tsconfig": "^2.0.0",
                 "@lokalise/universal-testing-utils": "^2.0.0",
                 "@opentelemetry/sdk-trace-node": "^2.0.1",
+                "@readme/openapi-parser": "^5.0.1",
                 "@types/amqplib": "^0.10.7",
                 "@types/jsonwebtoken": "^9.0.10",
                 "@types/newrelic": "^9.14.8",
@@ -82,7 +83,6 @@
                 "cpy-cli": "^6.0.0",
                 "cross-env": "^10.0.0",
                 "mockttp": "^4.1.0",
-                "oas-validator": "^5.0.8",
                 "typescript": "5.9.2",
                 "vitest": "^3.2.4",
                 "yaml": "^2.8.1"
@@ -136,6 +136,45 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@apidevtools/json-schema-ref-parser": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.2.0.tgz",
+            "integrity": "sha512-NaGMMWwppbByagq+LwQMq6PMXHFWVu6kSwwx+eJfYTJ5zdpOvb9TIk6ZWxEEeXMUvGdVOZq3JalYsjsTZDvtkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-yaml": "^4.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/philsturgeon"
+            },
+            "peerDependencies": {
+                "@types/json-schema": "^7.0.15"
+            }
+        },
+        "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@apm-js-collab/code-transformer": {
@@ -2848,6 +2887,28 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@babel/code-frame": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -2879,6 +2940,16 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+            "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/types": {
@@ -4019,13 +4090,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@exodus/schemasafe": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
-            "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@fastify/ajv-compiler": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.2.tgz",
@@ -4395,6 +4459,16 @@
                 "safe-buffer": "^5.1.2",
                 "ws": "*",
                 "xtend": "^4.0.0"
+            }
+        },
+        "node_modules/@humanwhocodes/momoa": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+            "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.10.0"
             }
         },
         "node_modules/@inquirer/confirm": {
@@ -7439,6 +7513,68 @@
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
             "license": "BSD-3-Clause"
         },
+        "node_modules/@readme/better-ajv-errors": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-2.3.2.tgz",
+            "integrity": "sha512-T4GGnRAlY3C339NhoUpgJJFsMYko9vIgFAlhgV+/vEGFw66qEY4a4TRJIAZBcX/qT1pq5DvXSme+SQODHOoBrw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/code-frame": "^7.22.5",
+                "@babel/runtime": "^7.22.5",
+                "@humanwhocodes/momoa": "^2.0.3",
+                "jsonpointer": "^5.0.0",
+                "leven": "^3.1.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "ajv": "4.11.8 - 8"
+            }
+        },
+        "node_modules/@readme/better-ajv-errors/node_modules/leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@readme/openapi-parser": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-5.0.1.tgz",
+            "integrity": "sha512-qLHoqkBcqHmCFqLNuK9vH2DiOg+RM4Jk4ncgm6BkW1h796NAPqY6i4ux90PsgM19c4LVcZKgrEp+/oEGAAmCmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@apidevtools/json-schema-ref-parser": "^14.1.1",
+                "@readme/better-ajv-errors": "^2.3.2",
+                "@readme/openapi-schemas": "^3.1.0",
+                "@types/json-schema": "^7.0.15",
+                "ajv": "^8.12.0",
+                "ajv-draft-04": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "openapi-types": ">=7"
+            }
+        },
+        "node_modules/@readme/openapi-schemas": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@readme/openapi-schemas/-/openapi-schemas-3.1.0.tgz",
+            "integrity": "sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.44.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.1.tgz",
@@ -8659,6 +8795,13 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/jsonwebtoken": {
             "version": "9.0.10",
             "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
@@ -9732,13 +9875,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/call-me-maybe": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-            "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/camel-case": {
             "version": "4.1.2",
@@ -11946,13 +12082,6 @@
             "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
             "license": "MIT"
         },
-        "node_modules/http2-client": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
-            "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/http2-wrapper": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
@@ -13324,19 +13453,6 @@
                 }
             }
         },
-        "node_modules/node-fetch-h2": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
-            "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "http2-client": "^1.2.5"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            }
-        },
         "node_modules/node-gyp-build": {
             "version": "4.8.4",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -13375,111 +13491,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/oas-kit-common": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
-            "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "fast-safe-stringify": "^2.0.7"
-            }
-        },
-        "node_modules/oas-linter": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
-            "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@exodus/schemasafe": "^1.0.0-rc.2",
-                "should": "^13.2.1",
-                "yaml": "^1.10.0"
-            },
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
-        "node_modules/oas-linter/node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/oas-resolver": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
-            "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "node-fetch-h2": "^2.3.0",
-                "oas-kit-common": "^1.0.8",
-                "reftools": "^1.1.9",
-                "yaml": "^1.10.0",
-                "yargs": "^17.0.1"
-            },
-            "bin": {
-                "resolve": "resolve.js"
-            },
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
-        "node_modules/oas-resolver/node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/oas-schema-walker": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
-            "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
-        "node_modules/oas-validator": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
-            "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "call-me-maybe": "^1.0.1",
-                "oas-kit-common": "^1.0.8",
-                "oas-linter": "^3.2.2",
-                "oas-resolver": "^2.5.6",
-                "oas-schema-walker": "^1.1.5",
-                "reftools": "^1.1.9",
-                "should": "^13.2.1",
-                "yaml": "^1.10.0"
-            },
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
-        "node_modules/oas-validator/node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/object-assign": {
@@ -14420,16 +14431,6 @@
             "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
             "license": "Apache-2.0"
         },
-        "node_modules/reftools": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
-            "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
         "node_modules/request-ip": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
@@ -14795,66 +14796,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/should": {
-            "version": "13.2.3",
-            "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
-            "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "should-equal": "^2.0.0",
-                "should-format": "^3.0.3",
-                "should-type": "^1.4.0",
-                "should-type-adaptors": "^1.0.1",
-                "should-util": "^1.0.0"
-            }
-        },
-        "node_modules/should-equal": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
-            "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "should-type": "^1.4.0"
-            }
-        },
-        "node_modules/should-format": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-            "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "should-type": "^1.3.0",
-                "should-type-adaptors": "^1.0.1"
-            }
-        },
-        "node_modules/should-type": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-            "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/should-type-adaptors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
-            "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "should-type": "^1.3.0",
-                "should-util": "^1.0.0"
-            }
-        },
-        "node_modules/should-util": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
-            "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/side-channel": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
         "@lokalise/tsconfig": "^2.0.0",
         "@lokalise/universal-testing-utils": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.1",
+        "@readme/openapi-parser": "^5.0.1",
         "@types/amqplib": "^0.10.7",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/newrelic": "^9.14.8",
@@ -108,7 +109,6 @@
         "cpy-cli": "^6.0.0",
         "cross-env": "^10.0.0",
         "mockttp": "^4.1.0",
-        "oas-validator": "^5.0.8",
         "typescript": "5.9.2",
         "vitest": "^3.2.4",
         "yaml": "^2.8.1"

--- a/scripts/oas-validator.d.ts
+++ b/scripts/oas-validator.d.ts
@@ -1,3 +1,0 @@
-declare module 'oas-validator' {
-  export function validate(openapi: unknown, options: unknown): Promise<unknown>
-}

--- a/scripts/validateOpenApi.ts
+++ b/scripts/validateOpenApi.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import { validate } from '@readme/openapi-parser'
+import { compileErrors, validate } from '@readme/openapi-parser'
 import { parse as fromYaml } from 'yaml'
 import { consoleLog } from './utils/loggingUtils.ts'
 import { getRootDirectory } from './utils/pathUtils.ts'
@@ -13,8 +13,10 @@ async function run() {
   if (validationResult.valid) {
     consoleLog('Document is valid')
   } else {
-    consoleLog(`Errors: ${JSON.stringify(validationResult.errors)})`)
-    consoleLog(`Warnings: ${JSON.stringify(validationResult.warnings)})`)
+    consoleLog(`Errors:\n${compileErrors(validationResult)}`)
+    if (validationResult.warnings?.length) {
+      consoleLog(`Warnings: ${JSON.stringify(validationResult.warnings)}`)
+    }
     throw new Error('Specification validation has failed')
   }
 }


### PR DESCRIPTION
1) OpenAPI 3.1 support;
2) Much easier to consume errors;
3) No need to try-catch to get errors;
4) Proper TypeScript support