### PR TITLE
Add dependabot cooldown to protect against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,16 @@ updates:
     schedule:
       interval: 'monthly'
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     groups:
       types:
         patterns:


### PR DESCRIPTION
This ensures that only package releases that are at least a week old will be included in dependabot updates.