### PR TITLE
upgrade to OpenAPI 3.1.0 to fix nullable types in Scalar docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.10.0] - 2026-04-28
+
+- Upgrade OpenAPI spec to 3.1.0 and set `zodToJsonConfig.target` to `draft-2020-12` in `createJsonSchemaTransform`; fixes nullable objects and arrays being incorrectly described in Scalar API reference docs
+
 ## [1.9.0] - 2026-04-23
 
 - Add a dedicated Biome config for workspace packages: root `biome.jsonc` is now `root: true` and excludes `packages`; new `packages/biome.jsonc` is an independent root extending `biome-base`, `biome-esm`, and `biome-package`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-service-template",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "engines": {
         "node": ">=24.5.0"
     },

--- a/src/app.ts
+++ b/src/app.ts
@@ -145,6 +145,9 @@ export async function getApp(
   await app.register(fastifyAuth)
   await app.register(fastifySwagger, {
     transform: createJsonSchemaTransform({
+      zodToJsonConfig: {
+        target: 'draft-2020-12',
+      },
       skipList: [
         '/documentation/',
         '/documentation/initOAuth',
@@ -156,6 +159,7 @@ export async function getApp(
       ],
     }),
     openapi: {
+      openapi: '3.1.0',
       info: {
         title: 'SampleApi',
         description: 'Sample backend service',


### PR DESCRIPTION
## Summary

 - Upgrade OpenAPI spec to 3.1.0 and set zodToJsonConfig.target to draft-2020-12
 - Fixes nullable objects/arrays rendered incorrectly in Scalar — 3.1.0 uses type: ['Foo', 'null'] instead of the 3.0.x `nullable: true` that Scalar didn't handle correctly
        