### PR TITLE
chore: tighten Dockerfile cache layout and add pnpm cache mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # ---- Base Node ----
 FROM node:24.15.0-trixie-slim AS base
 
@@ -11,7 +13,14 @@ RUN set -ex && \
 # is used consistently across local, CI, and Docker builds.
 RUN corepack enable
 
-RUN mkdir -p /home/node/app && chown -R node:node /home/node && chmod -R 770 /home/node
+# /pnpm hosts the pnpm store via a BuildKit cache mount in the deps stages
+# below; create it as node-owned so non-root installs can write to it.
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN mkdir -p /pnpm/store /home/node/app && \
+    chown -R node:node /pnpm /home/node && \
+    chmod -R 770 /home/node
+
 WORKDIR /home/node/app
 
 # ---- Production dependencies ----
@@ -22,7 +31,8 @@ COPY --chown=node:node ./package.json ./pnpm-lock.yaml ./pnpm-workspace.yaml ./
 COPY --chown=node:node ./packages/api-contracts/package.json ./packages/api-contracts/package.json
 
 USER node
-RUN set -ex; \
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store,uid=1000,gid=1000 \
+    set -ex; \
     pnpm install --frozen-lockfile --ignore-scripts --prod;
 
 # ---- Build ----
@@ -33,7 +43,8 @@ COPY --chown=node:node ./packages/api-contracts/package.json ./packages/api-cont
 
 USER node
 # Full install including devDependencies needed to build the service.
-RUN set -ex; \
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store,uid=1000,gid=1000 \
+    set -ex; \
     pnpm install --frozen-lockfile --ignore-scripts;
 
 COPY --chown=node:node . .
@@ -42,6 +53,11 @@ RUN pnpm run build
 # ---- Release ----
 FROM base AS release
 
+# Stable runtime config first.
+ENV NODE_ENV=production
+ENV NODE_PATH=.
+ENV APP_PORT=3000
+
 # Production node_modules (with pnpm symlinks into workspace packages)
 COPY --chown=node:node --from=production-deps /home/node/app/node_modules ./node_modules
 # Workspace packages referenced via symlinks from node_modules
@@ -49,17 +65,8 @@ COPY --chown=node:node --from=build /home/node/app/packages ./packages
 COPY --chown=node:node --from=build /home/node/app/src/db/migrations ./src/db/migrations
 COPY --chown=node:node --from=build /home/node/app/dist ./
 
-ARG GIT_COMMIT_SHA=""
-ARG APP_VERSION=""
-
-ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
-ENV APP_VERSION=${APP_VERSION}
-ENV NODE_ENV=production
-ENV NODE_PATH=.
-
 USER node
 
-ENV APP_PORT=3000
 # EXPOSE is resolved at build time, so it documents the default APP_PORT (3000).
 # Override APP_PORT at runtime with `-e APP_PORT=...` and publish with `-p <host>:<app_port>`.
 EXPOSE 3000
@@ -68,5 +75,15 @@ EXPOSE 3000
 # is not killed when external dependencies (Postgres, Redis) are temporarily down.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
     CMD node -e "fetch(\`http://localhost:${process.env.APP_PORT || 3000}/live\`).then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"
+
+# Volatile build metadata last: a new commit only invalidates this thin
+# trailing layer, leaving the heavy COPY layers above cache-eligible.
+ARG GIT_COMMIT_SHA=""
+ARG APP_VERSION=""
+ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
+ENV APP_VERSION=${APP_VERSION}
+LABEL org.opencontainers.image.revision=${GIT_COMMIT_SHA} \
+      org.opencontainers.image.version=${APP_VERSION} \
+      org.opencontainers.image.source="https://github.com/lokalise/node-service-template"
 
 CMD ["dumb-init", "node", "--import=@opentelemetry/instrumentation/hook.mjs", "server.js"]


### PR DESCRIPTION
## Description

Three small Dockerfile changes that improve build cache reuse and add image traceability, without changing runtime behavior:

1. **`# syntax=docker/dockerfile:1`** at the top so BuildKit features (cache mounts, `COPY --parents`, secret mounts) are unconditionally available.
2. **pnpm store cache mount.** Both the `production-deps` and `build` stages now run `pnpm install` under `--mount=type=cache,id=pnpm,target=/pnpm/store,uid=1000,gid=1000`. The pnpm content-addressable store persists across cold BuildKit containers, so package downloads aren't repeated on every fresh CI run. The cache target path is invisible to layer hashing, so this doesn't affect the cache key.
3. **Release stage reordered.**
   - Stable runtime ENVs (`NODE_ENV`, `NODE_PATH`, `APP_PORT`) moved above the `COPY --from=…` lines.
   - Volatile build metadata (`ARG GIT_COMMIT_SHA`, `ARG APP_VERSION`, the matching `ENV`s, and a new `LABEL` block) moved to the very end of the stage, after `HEALTHCHECK` and just before `CMD`.
   - Net effect: a new commit only invalidates the thin trailing label layer instead of forcing every layer below the metadata block to rebuild.
4. **OCI labels** for `org.opencontainers.image.revision`, `version`, and `source` so the image carries traceable provenance.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**