### PR TITLE
chore(deps): bump @lokalise/opentelemetry-fastify-bootstrap to ^3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.12.1] - 2026-05-26
+
+- Bump `@lokalise/opentelemetry-fastify-bootstrap` from `^2.2.0` to `^3.0.0`; v3 is a peer-dependency-only major (it now requires `@fastify/otel 0.18.1`, `@opentelemetry/auto-instrumentations-node ^0.76.0`, `@opentelemetry/sdk-node`/`exporter-trace-otlp-grpc ^0.218.0`, `@opentelemetry/sdk-trace-base ^2.7.1` — all already pinned here), with no public API changes to `initOpenTelemetry`/`gracefulOtelShutdown`
+
 ## [1.12.0] - 2026-05-26
 
 - Bump all `package.json` dependencies to latest allowed by pnpm's `minimum-release-age` filter; notable major bumps: `amqplib` 1 → 2, `awilix-manager` 6 → 7, `toad-scheduler` 3 → 4, `@lokalise/backend-http-client` 10 → 11, `@lokalise/fastify-extras` 30 → 31, plus the OTel ecosystem (`@fastify/otel` 0.17.1 → 0.18.1, `@opentelemetry/exporter-trace-otlp-grpc` 0.210.0 → 0.218.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-service-template",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "engines": {
         "node": ">=24.16.0"
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "@lokalise/fastify-extras": "^31.0.0",
         "@lokalise/healthcheck-utils": "^6.0.0",
         "@lokalise/node-core": "^14.8.1",
-        "@lokalise/opentelemetry-fastify-bootstrap": "^2.2.0",
+        "@lokalise/opentelemetry-fastify-bootstrap": "^3.0.0",
         "@lokalise/universal-ts-utils": "^4.10.0",
         "@lokalise/zod-extras": "^3.0.2",
         "@message-queue-toolkit/amqp": "^24.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^14.8.1
         version: 14.8.1(zod@4.4.3)
       '@lokalise/opentelemetry-fastify-bootstrap':
-        specifier: ^2.2.0
-        version: 2.2.0(@fastify/otel@0.18.1(@opentelemetry/api@1.9.1))(@opentelemetry/auto-instrumentations-node@0.76.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)))(@opentelemetry/exporter-trace-otlp-grpc@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-node@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(fastify@5.8.5)
+        specifier: ^3.0.0
+        version: 3.0.0(@fastify/otel@0.18.1(@opentelemetry/api@1.9.1))(@opentelemetry/auto-instrumentations-node@0.76.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)))(@opentelemetry/exporter-trace-otlp-grpc@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-node@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(fastify@5.8.5)
       '@lokalise/universal-ts-utils':
         specifier: ^4.10.0
         version: 4.10.0
@@ -1027,14 +1027,14 @@ packages:
     peerDependencies:
       zod: '>=3.25.76 <5.0.0'
 
-  '@lokalise/opentelemetry-fastify-bootstrap@2.2.0':
-    resolution: {integrity: sha512-X+hQLyF5DYZjWHLZ9sKSbfZ2Omp4FwoCfv+bbAty8EUup6FkHYZddBhyj3p/PjX/Zau/rQl/dbhpwBrxWgwFEQ==}
+  '@lokalise/opentelemetry-fastify-bootstrap@3.0.0':
+    resolution: {integrity: sha512-lASlgyH2980rd9Ejl8sgEdVf/8qt9yqzmS5B1AdS7OteLNYX+P7FkaBEZ2hwlYVMZQEPrp+trQjHJLjHds6+cA==}
     peerDependencies:
-      '@fastify/otel': 0.17.1
-      '@opentelemetry/auto-instrumentations-node': ^0.68.0
-      '@opentelemetry/exporter-trace-otlp-grpc': ^0.210.0
-      '@opentelemetry/sdk-node': ^0.210.0
-      '@opentelemetry/sdk-trace-base': ^2.4.0
+      '@fastify/otel': 0.18.1
+      '@opentelemetry/auto-instrumentations-node': ^0.76.0
+      '@opentelemetry/exporter-trace-otlp-grpc': ^0.218.0
+      '@opentelemetry/sdk-node': ^0.218.0
+      '@opentelemetry/sdk-trace-base': ^2.7.1
       fastify: ^5.0.0
 
   '@lokalise/tsconfig@4.0.0':
@@ -5181,7 +5181,7 @@ snapshots:
       tslib: 2.8.1
       zod: 4.4.3
 
-  '@lokalise/opentelemetry-fastify-bootstrap@2.2.0(@fastify/otel@0.18.1(@opentelemetry/api@1.9.1))(@opentelemetry/auto-instrumentations-node@0.76.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)))(@opentelemetry/exporter-trace-otlp-grpc@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-node@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(fastify@5.8.5)':
+  '@lokalise/opentelemetry-fastify-bootstrap@3.0.0(@fastify/otel@0.18.1(@opentelemetry/api@1.9.1))(@opentelemetry/auto-instrumentations-node@0.76.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)))(@opentelemetry/exporter-trace-otlp-grpc@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-node@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(fastify@5.8.5)':
     dependencies:
       '@fastify/otel': 0.18.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/auto-instrumentations-node': 0.76.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ allowBuilds:
   protobufjs: false
 minimumReleaseAgeExclude:
   - '@message-queue-toolkit/sns@25.0.1'
+  - '@lokalise/opentelemetry-fastify-bootstrap@3.0.0'


### PR DESCRIPTION
## Summary
- Bumps `@lokalise/opentelemetry-fastify-bootstrap` from `^2.2.0` to `^3.0.0`.
- v3 is a major bump driven by peer-dependency updates (`@fastify/otel` 0.18.1, `@opentelemetry/auto-instrumentations-node` ^0.76.0, `@opentelemetry/sdk-node`/`exporter-trace-otlp-grpc` ^0.218.0, `@opentelemetry/sdk-trace-base` ^2.7.1). Our project already pins these versions, so no other code changes were needed. The library's `initOpenTelemetry` / `gracefulOtelShutdown` API surface is unchanged.

## Test plan
- [x] `pnpm install` succeeds; lockfile updated
- [x] `tsc --noEmit` passes
- [x] Full vitest suite passes (70/70)
- [x] `src/infrastructure/openTelemetryBootstrap.spec.ts` passes — confirms `@fastify/otel` request spans are still emitted end-to-end through the real app