### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+      # Open PRs inside the automerge window (see ci.yml) so they are not skipped.
+      time: '10:00'
+      timezone: 'Europe/Berlin'
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -14,6 +17,9 @@ updates:
       - '/packages/*'
     schedule:
       interval: 'weekly'
+      # Open PRs inside the automerge window (see ci.yml) so they are not skipped.
+      time: '10:00'
+      timezone: 'Europe/Berlin'
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
         node-version: [24.17, 26.x]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.8
+        uses: pnpm/action-setup@v6.0.9
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,8 @@ jobs:
       - uses: fastify/github-action-merge-dependabot@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Only auto-merge during business hours: Mon-Fri, 10:00-16:59 Berlin time.
+          # Conservative window so a human is around across common European timezones
+          # when a merge lands (10:00 Berlin = 09:00 London; 16:59 Berlin = 17:59 Helsinki).
+          merge-window: '* 10-16 * * 1-5'
+          merge-window-timezone: 'Europe/Berlin'

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Run Docker healthcheck test
         run: ./scripts/docker-healthcheck-test.sh


### PR DESCRIPTION
Updates GitHub Actions to their latest versions and restricts Dependabot auto-merge to business hours.

## Version bumps

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v6 | v7 |
| `pnpm/action-setup` | 6.0.8 | 6.0.9 |

`actions/setup-node@v6.4.0` and `fastify/github-action-merge-dependabot@v3` were already current.

## Business-hours auto-merge

Added a `merge-window` to the merge-dependabot action so updates only auto-merge **Mon-Fri, 10:00-16:59 `Europe/Berlin`**. The window is deliberately conservative so a human is around across common European timezones when a merge lands (10:00 Berlin = 09:00 London; 16:59 Berlin = 17:59 Helsinki).

The action does not retry PRs it skips outside the window, so Dependabot's PR open time is set to 10:00 Berlin (`time`/`timezone` in `dependabot.yml`) to ensure PRs land inside the window.

Config reference: [merge-window / merge-window-timezone](https://github.com/fastify/github-action-merge-dependabot#readme).

🤖 Generated with [Claude Code](https://claude.com/claude-code)