### PR TITLE
feat: app-scoped AbortSignal for CLI graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.14.0] - 2026-06-29
+
+- Add an app-scoped `AbortController` to the cradle (`src/infrastructure/CommonModule.ts`) and abort it from the `gracefulShutdown` handler in `src/app.ts` so any consumer wired to `appAbortController.signal` can short-circuit in-flight work on SIGTERM/SIGINT
+- Expose that signal via `lifecycle.signal` in `scripts/utils/cliCommandWrapper.ts`; the wrapper now also registers its own `gracefulShutdown` handler that awaits the command's completion before resolving, so the plugin no longer calls `app.close()` while a CLI command is still mid-iteration (commands can poll `lifecycle.signal.aborted` and/or pass the signal directly to AbortSignal-aware APIs like `node:timers/promises`, `undici`/`fetch`, or the ES client)
+- Add `scripts/dummy/lifecycle-loop.ts` — a long-running fixture used by the new integration test below
+- Add `scripts/utils/cliCommandWrapper.integration.spec.ts` — spawns the lifecycle-loop fixture as a child process under `NODE_ENV=production` so `fastify-graceful-shutdown` is registered, sends SIGTERM, and asserts the abort propagated through `lifecycle.signal`, the loop exited cleanly, and the process returned exit code 0
+
 ## [1.13.0] - 2026-05-27
 
 - Drop `drizzle-zod` dependency and switch to the built-in `drizzle-orm/zod`, eliminating a separate package from the dependency tree

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-service-template",
-    "version": "1.13.0",
+    "version": "1.14.0",
     "engines": {
         "node": ">=24.16.0"
     },

--- a/scripts/dummy/lifecycle-loop.ts
+++ b/scripts/dummy/lifecycle-loop.ts
@@ -1,0 +1,21 @@
+import { setTimeout } from 'node:timers/promises'
+import { cliCommandWrapper } from '../utils/cliCommandWrapper.ts'
+
+// Long-running loop used by cliCommandWrapper's integration test to assert that
+// the app-scoped AbortSignal propagates through `lifecycle.signal` and cleanly
+// exits the loop when SIGTERM arrives. Spawned as a child process by the spec.
+await cliCommandWrapper(
+  'lifecycle-loop',
+  async (_dependencies, requestContext, _args, lifecycle) => {
+    requestContext.logger.info('LOOP_STARTED')
+
+    let iteration = 0
+    while (!lifecycle.signal.aborted) {
+      iteration += 1
+      requestContext.logger.info({ iteration }, 'tick')
+      await setTimeout(100, undefined, { signal: lifecycle.signal }).catch(() => {})
+    }
+
+    requestContext.logger.warn({ iteration }, 'LOOP_EXITED_CLEANLY')
+  },
+)

--- a/scripts/utils/cliCommandWrapper.integration.spec.ts
+++ b/scripts/utils/cliCommandWrapper.integration.spec.ts
@@ -1,0 +1,75 @@
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import { setTimeout as wait } from 'node:timers/promises'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(__dirname, '../..')
+const LOOP_SCRIPT = path.join(REPO_ROOT, 'scripts/dummy/lifecycle-loop.ts')
+const READY_DEADLINE_MS = 10_000
+const EXIT_DEADLINE_MS = 10_000
+
+const waitFor = async (predicate: () => boolean, deadlineMs: number, label: string) => {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > deadlineMs) {
+      throw new Error(`Timed out waiting for: ${label}`)
+    }
+    await wait(50)
+  }
+}
+
+describe('cliCommandWrapper — SIGTERM abort propagation (integration)', () => {
+  it('aborts the running command via lifecycle.signal and exits cleanly', async () => {
+    // NODE_ENV=production triggers `fastify-graceful-shutdown` registration in
+    // src/app.ts. Without it, SIGTERM would force-kill the process instead of
+    // routing through our handler.
+    const child = spawn('node', ['--env-file-if-exists=.env', LOOP_SCRIPT], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, NODE_ENV: 'production' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let output = ''
+    child.stdout.on('data', (chunk) => {
+      output += chunk.toString()
+    })
+    child.stderr.on('data', (chunk) => {
+      output += chunk.toString()
+    })
+
+    const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) =>
+      child.on('exit', (code, signal) => resolve({ code, signal })),
+    )
+
+    try {
+      // Let the loop run a few iterations so we can prove the abort actually
+      // interrupted real work (vs. the script crashing on startup).
+      await waitFor(
+        () => /"iteration":\s*3/.test(output),
+        READY_DEADLINE_MS,
+        'loop to reach iteration 3',
+      )
+
+      child.kill('SIGTERM')
+
+      const result = await Promise.race([
+        exited,
+        wait(EXIT_DEADLINE_MS).then(() => {
+          throw new Error('Child did not exit within deadline after SIGTERM')
+        }),
+      ])
+
+      expect(result.signal).toBeNull()
+      expect(result.code).toBe(0)
+      expect(output).toContain('LOOP_STARTED')
+      expect(output).toContain('Shutdown signal received, stopping after current step')
+      expect(output).toContain('LOOP_EXITED_CLEANLY')
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGKILL')
+      }
+    }
+  }, 30_000)
+})

--- a/scripts/utils/cliCommandWrapper.ts
+++ b/scripts/utils/cliCommandWrapper.ts
@@ -47,10 +47,19 @@ const getArgs = (argsSchema: z.Schema) => {
   return values
 }
 
+export type CliCommandLifecycle = {
+  signal: AbortSignal
+}
+
 export type CliCommand<
   ArgsSchema extends z.Schema | undefined,
   Args = ArgsSchema extends z.Schema ? z.infer<ArgsSchema> : undefined,
-> = (dependencies: Dependencies, requestContext: RequestContext, args: Args) => Promise<void> | void
+> = (
+  dependencies: Dependencies,
+  requestContext: RequestContext,
+  args: Args,
+  lifecycle: CliCommandLifecycle,
+) => Promise<void> | void
 
 export const cliCommandWrapper = async <ArgsSchema extends z.Schema | undefined>(
   cliCommandName: string,
@@ -81,6 +90,27 @@ export const cliCommandWrapper = async <ArgsSchema extends z.Schema | undefined>
     }),
   }
 
+  // The app-scoped abort signal is aborted by app.ts's gracefulShutdown handler
+  // (only registered in non-dev). Commands can observe `lifecycle.signal.aborted`
+  // and/or pass `lifecycle.signal` to any AbortSignal-aware API.
+  //
+  // The handler below must still await `commandDone` — abort is a notification,
+  // not synchronization, so without this the plugin would call `app.close()`
+  // while the command is still unwinding.
+  const lifecycle: CliCommandLifecycle = {
+    signal: app.diContainer.cradle.appAbortController.signal,
+  }
+  let resolveCommandDone!: () => void
+  const commandDone = new Promise<void>((resolve) => {
+    resolveCommandDone = resolve
+  })
+  if (typeof app.gracefulShutdown === 'function') {
+    app.gracefulShutdown(async (signal) => {
+      reqContext.logger.warn({ signal }, 'Shutdown signal received, stopping after current step')
+      await commandDone
+    })
+  }
+
   let args = undefined as ArgsSchema extends z.Schema ? z.infer<ArgsSchema> : undefined
   if (argsSchema) {
     const parseResult = argsSchema.safeParse(getArgs(argsSchema))
@@ -100,7 +130,7 @@ export const cliCommandWrapper = async <ArgsSchema extends z.Schema | undefined>
 
   let isSuccess = true
   try {
-    await command(app.diContainer.cradle, reqContext, args)
+    await command(app.diContainer.cradle, reqContext, args, lifecycle)
   } catch (err) {
     isSuccess = false
     reqContext.logger.error(
@@ -109,6 +139,8 @@ export const cliCommandWrapper = async <ArgsSchema extends z.Schema | undefined>
       },
       'Error running command',
     )
+  } finally {
+    resolveCommandDone()
   }
 
   await app.close()

--- a/src/app.ts
+++ b/src/app.ts
@@ -333,10 +333,15 @@ export async function getApp(
     // Register routes
     diContext.registerRoutes(app)
 
-    // Graceful shutdown hook
+    // Graceful shutdown hook — abort the app-scoped controller so any consumer
+    // wired to `appAbortController.signal` (CLI loops, long-running I/O, …) can
+    // short-circuit in-flight work.
     if (!nodeEnv.isDevelopment) {
-      app.gracefulShutdown(async (_signal) => {
-        app.log.info('Starting graceful shutdown')
+      app.gracefulShutdown(async (signal) => {
+        diContainer.cradle.appAbortController.abort(
+          new Error(`Shutdown signal received: ${signal}`),
+        )
+        app.log.info({ signal }, 'Starting graceful shutdown')
         await gracefulOtelShutdown()
       })
     }

--- a/src/infrastructure/CommonModule.ts
+++ b/src/infrastructure/CommonModule.ts
@@ -94,6 +94,8 @@ export class CommonModule extends AbstractModule<unknown, ExternalDependencies> 
       }),
       logger: asSingletonFunction(() => externalDependencies.logger, { public: true }),
 
+      appAbortController: asSingletonFunction(() => new AbortController(), { public: true }),
+
       scheduler: asSingletonFunction(
         () => {
           return externalDependencies.app?.scheduler ?? new ToadScheduler()


### PR DESCRIPTION
Register an `appAbortController` in the cradle and abort it from app.ts's gracefulShutdown handler so any consumer wired to the signal can short-circuit in-flight work on SIGTERM. The CLI wrapper now exposes that signal via `lifecycle.signal` and registers its own gracefulShutdown handler that awaits the command's completion before letting the plugin tear down the app — without this, the plugin would call app.close() while the command is still mid-iteration.

Adds scripts/dummy/lifecycle-loop.ts as a long-running fixture and scripts/utils/cliCommandWrapper.integration.spec.ts which spawns the fixture under NODE_ENV=production, sends SIGTERM, and asserts the command observes the signal and exits cleanly.