### PR TITLE
chore: CLI command wrapper -> Support for zod pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.14.0] - 2026-07-17
+
+- Support zod schemas with `.transform()`/`.pipe()` in `scripts/utils/cliCommandWrapper.ts`: `deriveParseArgsOptions` now resolves the flag-defining `ZodObject` through the input side of a `ZodPipe` (new `resolveInputObjectSchema` helper), so a CLI script can declare flat flags and transform them into a nested, schema-validated args object in a single `argsSchema` — command handlers receive the transformed output while `parseArgs` options (including repeatable/`multiple` flags) are still derived from the flat input shape
+- Add spec coverage for transformed and piped args schemas in `scripts/utils/cliCommandWrapper.spec.ts`
+
 ## [1.13.0] - 2026-05-27
 
 - Drop `drizzle-zod` dependency and switch to the built-in `drizzle-orm/zod`, eliminating a separate package from the dependency tree

--- a/README.md
+++ b/README.md
@@ -236,9 +236,9 @@ If any variable is not documented you will see a list of undocumented ones:
 
 ## CLI Commands
 
-To create a new CLI command, create a new file in the [scripts/cmd](./scripts/cmd) directory. The file should be self-executable. The process should create a CLI context using `cliContextUtils.ts` and destroy it before exiting.
+To create a new CLI command, create a new file in the [scripts/cmd](./scripts/cmd) directory. The file should be self-executable and wrap its logic with [cliCommandWrapper](./scripts/utils/cliCommandWrapper.ts), which boots the app, parses and validates arguments, and handles logging, graceful shutdown, and exit codes.
 
-To use arguments in your command, ZOD schema and generic type should be provided in `createCliContext()`. Arguments will be parsed and validated using the provided schema.
+To use arguments in your command, provide a zod schema to `cliCommandWrapper()`. CLI flags are derived from the schema itself — string, boolean, repeatable (array) and optional flags are supported, and the schema may end in `.transform()`/`.pipe()` to reshape flat flags into a nested args object. See [docs/cli-commands.md](./docs/cli-commands.md) for the full description of what is supported.
 
 Create a new command in the `scripts` section of `package.json`:
 

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -1,0 +1,93 @@
+# CLI commands
+
+CLI commands are self-executable scripts that run a piece of application logic with the full DI container available, outside of the HTTP server. They live in [scripts/cmd](../scripts/cmd) and are built on top of [cliCommandWrapper](../scripts/utils/cliCommandWrapper.ts).
+
+## Anatomy of a command
+
+```ts
+import type { RequestContext } from '@lokalise/fastify-extras'
+import z from 'zod/v4'
+import type { Dependencies } from '../../src/infrastructure/CommonModule.ts'
+import { cliCommandWrapper } from '../utils/cliCommandWrapper.ts'
+
+const ARGUMENTS_SCHEMA = z.object({
+  queue: z.enum(['active', 'failed', 'delayed', 'completed', 'waiting', 'prioritized']),
+})
+type Arguments = z.infer<typeof ARGUMENTS_SCHEMA>
+
+const command = async (deps: Dependencies, reqContext: RequestContext, args: Arguments) => {
+  // application logic; `deps` is the DI cradle, `reqContext.logger` is scoped to this invocation
+}
+
+void cliCommandWrapper('getUserImportJobsCommand', command, ARGUMENTS_SCHEMA)
+```
+
+The wrapper:
+
+- boots the app with the HTTP-facing and background features disabled (healthchecks, monitoring, periodic jobs, message queue consumers, enqueued job workers) and job queues enabled, so commands can schedule jobs;
+- creates a per-invocation `RequestContext` with a child logger tagged with the command name and a fresh `x-request-id`;
+- parses and validates CLI arguments against the provided zod schema (see below); on validation failure it logs `Invalid arguments` with the zod issues and exits with code `1`;
+- runs the command, logs any thrown error as `Error running command`, closes the app, and exits with code `0` on success or `1` on failure.
+
+Register the command in the `scripts` section of `package.json` and run it with `node --run {npmScriptName} -- {arguments}`.
+
+## Argument schemas: what is supported
+
+`cliCommandWrapper` derives the `node:util` `parseArgs` options from the zod schema itself, so the schema is the single source of truth for both parsing and validation. The schema must be a `z.object(...)` — optionally followed by `.transform(...)` and/or `.pipe(...)` — whose keys are the flag names.
+
+Supported field types on the flag-defining object:
+
+| Schema field                              | CLI behavior                                                       |
+| ----------------------------------------- | ------------------------------------------------------------------ |
+| `z.string()`, `z.enum([...])`, `z.guid()`, … | string flag: `--key=value`                                        |
+| `z.boolean()`                             | boolean flag: `--flag` (present → `true`)                          |
+| `z.array(<element>)`                      | repeatable flag: `--id=a --id=b` → `['a', 'b']`                    |
+| `.optional()` / `.nullable()` wrappers    | unwrapped transparently, both on fields and on array elements      |
+
+Notes:
+
+- Unknown flags are ignored (`parseArgs` runs with `strict: false`) and stripped by the object schema, so a typo in a flag name surfaces as a "missing required field" validation error rather than an unknown-flag error.
+- Anything after a bare `--` token in the final `process.argv` is treated as positionals and ignored — make sure your script runner does not forward the `--` separator itself.
+- Coercion beyond booleans is not performed by the parser: every value arrives as a string. Use a transform (below) or `z.coerce.*` on the schema if you need numbers.
+
+### Transforms and pipes
+
+The args schema can end in `.transform(...)` and/or `.pipe(...)`. Flags are always derived from the **input side** of the pipe (the flat `z.object`), while the command handler receives the fully transformed **output** (typed via `z.infer`). This lets a command declare flat flags and reshape them into the nested, schema-validated object its application layer expects, in a single schema:
+
+```ts
+const ARGUMENTS_SCHEMA = z
+  .object({
+    projectId: z.guid(),
+    itemId: z.array(z.guid()).optional(), // repeatable flag
+  })
+  .transform(({ projectId, itemId }, ctx) => {
+    const scopeResult = DOMAIN_SCOPE_SCHEMA.safeParse({ itemIds: itemId })
+    if (!scopeResult.success) {
+      for (const issue of scopeResult.error.issues) ctx.addIssue({ ...issue })
+      return z.NEVER
+    }
+    return { projectId, scope: scopeResult.data }
+  })
+```
+
+Issues added via `ctx.addIssue` (including ones re-raised from a nested `safeParse` against a shared domain schema) flow through the wrapper's regular `Invalid arguments` handling.
+
+Not supported:
+
+- `z.preprocess(fn, schema)` — its input side is the preprocess function itself, so there is no flag-defining object to derive `parseArgs` options from. Use `z.object(...).transform(...)` instead, which keeps the flat object on the input side.
+- Non-object root schemas (unions, records, primitives): no options can be derived, and repeatable/boolean flags will not parse correctly.
+
+## Graceful shutdown
+
+The command handler receives a fourth `lifecycle` argument exposing the app-scoped `AbortSignal`:
+
+```ts
+const command = async (deps, reqContext, args, lifecycle) => {
+  for (const batch of batches) {
+    if (lifecycle.signal.aborted) break
+    await processBatch(batch, { signal: lifecycle.signal })
+  }
+}
+```
+
+On SIGTERM/SIGINT (in non-dev environments, where `fastify-graceful-shutdown` is registered) the signal is aborted and the wrapper waits for the command to finish its current step before closing the app. Long-running commands should poll `lifecycle.signal.aborted` between units of work and/or pass the signal to AbortSignal-aware APIs (`node:timers/promises`, `undici`/`fetch`, etc.). See [cliCommandWrapper.integration.spec.ts](../scripts/utils/cliCommandWrapper.integration.spec.ts) for an end-to-end example.

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -1,35 +1,83 @@
 # CLI commands
 
-CLI commands are self-executable scripts that run a piece of application logic with the full DI container available, outside of the HTTP server. They live in [scripts/cmd](../scripts/cmd) and are built on top of [cliCommandWrapper](../scripts/utils/cliCommandWrapper.ts).
+CLI commands are self-executable scripts that run a piece of application logic with the full DI container available, outside of the HTTP server — one-off maintenance tasks, backfills, queue inspection, debugging helpers. They live in [scripts/cmd](../scripts/cmd) and are built on top of [cliCommandWrapper](../scripts/utils/cliCommandWrapper.ts).
 
-## Anatomy of a command
+## Quick start
+
+A command is a file with three parts: an arguments schema, a handler, and the wrapper call. As a worked example, a command that re-sends welcome emails to a list of users, with an optional dry-run mode:
 
 ```ts
+// scripts/cmd/resendWelcomeEmail.ts
 import type { RequestContext } from '@lokalise/fastify-extras'
 import z from 'zod/v4'
 import type { Dependencies } from '../../src/infrastructure/CommonModule.ts'
 import { cliCommandWrapper } from '../utils/cliCommandWrapper.ts'
 
 const ARGUMENTS_SCHEMA = z.object({
-  queue: z.enum(['active', 'failed', 'delayed', 'completed', 'waiting', 'prioritized']),
+  userId: z.array(z.guid()).min(1), // repeatable flag
+  dryRun: z.boolean().optional(),
 })
 type Arguments = z.infer<typeof ARGUMENTS_SCHEMA>
 
 const command = async (deps: Dependencies, reqContext: RequestContext, args: Arguments) => {
-  // application logic; `deps` is the DI cradle, `reqContext.logger` is scoped to this invocation
+  for (const userId of args.userId) {
+    if (args.dryRun) {
+      reqContext.logger.info({ userId }, 'dry run - would resend welcome email')
+      continue
+    }
+    await deps.userService.resendWelcomeEmail(userId)
+  }
 }
 
-void cliCommandWrapper('getUserImportJobsCommand', command, ARGUMENTS_SCHEMA)
+void cliCommandWrapper('resendWelcomeEmailCommand', command, ARGUMENTS_SCHEMA)
 ```
 
-The wrapper:
+Register it in the `scripts` section of `package.json`, following the `cmd:` prefix convention:
 
-- boots the app with the HTTP-facing and background features disabled (healthchecks, monitoring, periodic jobs, message queue consumers, enqueued job workers) and job queues enabled, so commands can schedule jobs;
-- creates a per-invocation `RequestContext` with a child logger tagged with the command name and a fresh `x-request-id`;
-- parses and validates CLI arguments against the provided zod schema (see below); on validation failure it logs `Invalid arguments` with the zod issues and exits with code `1`;
-- runs the command, logs any thrown error as `Error running command`, closes the app, and exits with code `0` on success or `1` on failure.
+```json
+"scripts": {
+  "cmd:resendWelcomeEmail": "node --env-file-if-exists=.env scripts/cmd/resendWelcomeEmail.ts"
+}
+```
 
-Register the command in the `scripts` section of `package.json` and run it with `node --run {npmScriptName} -- {arguments}`.
+Run it with `node --run {npmScriptName} -- {arguments}`:
+
+```shell
+node --run cmd:resendWelcomeEmail -- --userId=0198a3d2-... --userId=0198a3d5-... --dryRun
+```
+
+The flags above parse into:
+
+```ts
+{ userId: ['0198a3d2-...', '0198a3d5-...'], dryRun: true }
+```
+
+If validation fails — say, a `--userId` is not a valid GUID or the flag is missing entirely — the wrapper logs an `Invalid arguments` entry containing the zod issues and exits with code `1` without running the handler:
+
+```shell
+node --run cmd:resendWelcomeEmail -- --dryRun
+# logs: Invalid arguments … "path":["userId"],"message":"Invalid input: expected array, received undefined"
+# exit code: 1
+```
+
+See [getUserImportJobs.ts](../scripts/cmd/getUserImportJobs.ts) for a real command in this repository.
+
+## What the wrapper does
+
+- Boots the app with the HTTP-facing and background features disabled (healthchecks, monitoring, periodic jobs, message queue consumers, enqueued job workers) and job queues enabled, so commands can schedule jobs. If the app fails to boot, it logs `Failed to start {commandName}` and exits with code `1`.
+- Creates a per-invocation `RequestContext` with a child logger tagged with the command name and a fresh `x-request-id`, so every log line of a run is correlated.
+- Parses and validates CLI arguments against the provided zod schema (see below).
+- Runs the command handler with `(dependencies, requestContext, args, lifecycle)` — `dependencies` is the DI cradle, exactly what route handlers and consumers receive.
+- Logs any thrown error as `Error running command`, closes the app, and exits with the appropriate code.
+
+Exit codes:
+
+| Code | Meaning                                                       |
+| ---- | ------------------------------------------------------------- |
+| `0`  | Command completed without throwing                            |
+| `1`  | App failed to boot, arguments were invalid, or handler threw  |
+
+The arguments schema is optional — commands that take no arguments can call `cliCommandWrapper(name, command)` and receive `args: undefined`.
 
 ## Argument schemas: what is supported
 
@@ -37,18 +85,23 @@ Register the command in the `scripts` section of `package.json` and run it with 
 
 Supported field types on the flag-defining object:
 
-| Schema field                              | CLI behavior                                                       |
-| ----------------------------------------- | ------------------------------------------------------------------ |
-| `z.string()`, `z.enum([...])`, `z.guid()`, … | string flag: `--key=value`                                        |
-| `z.boolean()`                             | boolean flag: `--flag` (present → `true`)                          |
-| `z.array(<element>)`                      | repeatable flag: `--id=a --id=b` → `['a', 'b']`                    |
-| `.optional()` / `.nullable()` wrappers    | unwrapped transparently, both on fields and on array elements      |
+| Schema field                                 | CLI behavior                                                  | Example                          |
+| -------------------------------------------- | ------------------------------------------------------------- | -------------------------------- |
+| `z.string()`, `z.enum([...])`, `z.guid()`, … | string flag                                                    | `--queue=active`                 |
+| `z.boolean()`                                | boolean flag (present → `true`)                                | `--dryRun`                       |
+| `z.array(<element>)`                         | repeatable flag                                                | `--id=a --id=b` → `['a', 'b']`   |
+| `.optional()` / `.nullable()` wrappers       | unwrapped transparently, both on fields and on array elements  | omitting the flag → `undefined`  |
 
 Notes:
 
 - Unknown flags are ignored (`parseArgs` runs with `strict: false`) and stripped by the object schema, so a typo in a flag name surfaces as a "missing required field" validation error rather than an unknown-flag error.
 - Anything after a bare `--` token in the final `process.argv` is treated as positionals and ignored — make sure your script runner does not forward the `--` separator itself.
-- Coercion beyond booleans is not performed by the parser: every value arrives as a string. Use a transform (below) or `z.coerce.*` on the schema if you need numbers.
+- Coercion beyond booleans is not performed by the parser: every value arrives as a string. Use `z.coerce.number()` (or a transform, below) if you need numbers:
+
+  ```ts
+  z.object({ batchSize: z.coerce.number().int().positive().default(100) })
+  // --batchSize=250 → { batchSize: 250 }
+  ```
 
 ### Transforms and pipes
 
@@ -68,9 +121,20 @@ const ARGUMENTS_SCHEMA = z
     }
     return { projectId, scope: scopeResult.data }
   })
+
+// --projectId=<guid> --itemId=<guid> --itemId=<guid>
+//   → { projectId: '<guid>', scope: { itemIds: ['<guid>', '<guid>'] } }
 ```
 
-Issues added via `ctx.addIssue` (including ones re-raised from a nested `safeParse` against a shared domain schema) flow through the wrapper's regular `Invalid arguments` handling.
+Issues added via `ctx.addIssue` (including ones re-raised from a nested `safeParse` against a shared domain schema, as above) flow through the wrapper's regular `Invalid arguments` handling.
+
+A plain `.pipe(...)` also works when no reshaping is needed, e.g. to bolt a stricter output schema onto loosely-typed flags:
+
+```ts
+z.object({ count: z.string() })
+  .transform(({ count }) => ({ count: Number(count) }))
+  .pipe(z.object({ count: z.number().int() }))
+```
 
 Not supported:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-service-template",
-    "version": "1.13.0",
+    "version": "1.14.0",
     "engines": {
         "node": ">=24.16.0"
     },

--- a/scripts/utils/cliCommandWrapper.spec.ts
+++ b/scripts/utils/cliCommandWrapper.spec.ts
@@ -77,6 +77,38 @@ describe('cliCommandWrapper', () => {
     expect(exitSpy).toHaveBeenCalledWith(0)
   })
 
+  it.each([
+    {
+      inputArgs: ['--id=abc', '--id=def', '--scope=FIRST'],
+      schema: z
+        .object({ id: z.array(z.string()), scope: z.string() })
+        .transform(({ id, scope }) => ({ ids: id, isFirst: scope === 'FIRST' })),
+      expected: { ids: ['abc', 'def'], isFirst: true },
+    },
+    {
+      inputArgs: ['--count=5'],
+      schema: z
+        .object({ count: z.string() })
+        .transform(({ count }) => ({ count: Number(count) }))
+        .pipe(z.object({ count: z.number().int() })),
+      expected: { count: 5 },
+    },
+  ])('should derive flags from the input side of transformed schemas', async ({
+    inputArgs,
+    schema,
+    expected,
+  }) => {
+    process.argv = ['node', 'script.ts', ...inputArgs]
+    await cliCommandWrapper(
+      'command',
+      (_dependencies, _requestContext, args) => {
+        expect(args).toEqual(expected)
+      },
+      schema,
+    )
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
+
   it('should fail if arguments are not valid', async () => {
     process.argv = ['node', 'script.ts', '--key=value']
     await cliCommandWrapper('command', () => undefined, z.object({ key: z.number() }))

--- a/scripts/utils/cliCommandWrapper.ts
+++ b/scripts/utils/cliCommandWrapper.ts
@@ -11,11 +11,19 @@ import type { Dependencies } from '../../src/infrastructure/CommonModule.ts'
 const unwrapSchemaIfNeeded = (schema: z.Schema) =>
   schema instanceof z.ZodOptional || schema instanceof z.ZodNullable ? schema.unwrap() : schema
 
+const resolveInputObjectSchema = (schema: z.Schema): z.ZodObject | undefined => {
+  if (schema instanceof z.ZodObject) return schema
+  // schemas with transforms/pipes define their CLI flags on the input side of the pipe
+  if (schema instanceof z.ZodPipe) return resolveInputObjectSchema(schema.in as z.Schema)
+  return undefined
+}
+
 const deriveParseArgsOptions = (schema: z.Schema): ParseArgsOptionsConfig | undefined => {
-  if (!(schema instanceof z.ZodObject)) return undefined
+  const objectSchema = resolveInputObjectSchema(schema)
+  if (!objectSchema) return undefined
 
   const options: ParseArgsOptionsConfig = {}
-  for (const [key, fieldSchema] of Object.entries(schema.shape as Record<string, z.Schema>)) {
+  for (const [key, fieldSchema] of Object.entries(objectSchema.shape as Record<string, z.Schema>)) {
     const unwrappedFieldSchema = unwrapSchemaIfNeeded(fieldSchema)
 
     const isMultiple = unwrappedFieldSchema instanceof z.ZodArray


### PR DESCRIPTION
## Why

CLI scripts using `cliCommandWrapper` often need to reshape flat command-line flags into the nested, schema-validated objects the application layer expects (e.g. mapping repeatable `--targetLanguageIds` flags into a `{ scope, params }` discriminated union). Until now the `argsSchema` had to be a plain `z.object`, because `deriveParseArgsOptions` used its shape to derive the `parseArgs` options — so any mapping/validation against shared domain schemas had to be done manually inside each command handler.

## What

- `deriveParseArgsOptions` now resolves the flag-defining `ZodObject` through the input side of a `ZodPipe` (new `resolveInputObjectSchema` helper). Since `.transform()` and `.pipe()` produce `ZodPipe` wrappers, an `argsSchema` can now declare flat flags and transform them into the final args object in one place:

```ts
const argsSchema = z
  .object({ id: z.array(z.guid()), scope: z.string() })
  .transform(({ id, scope }, ctx) => {
    /* map flags into a nested object, optionally validating
       against a shared domain schema via safeParse + ctx.addIssue */
  })
```

Command handlers receive the transformed output (fully typed via `z.infer`), while `parseArgs` options — including repeatable/`multiple` flags — are still derived from the flat input shape. Validation errors from the transform flow through the existing `Invalid arguments` handling.

- Spec coverage added for both a `.transform()` schema with repeatable flags and a chained `.transform().pipe()` schema.
- `CHANGELOG.md` + version bump to `1.16.0`.

Plain `z.object` schemas keep working unchanged; `z.preprocess` is intentionally not supported because its input side is the preprocess function itself, so there is no flag shape to derive options from.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
