### PR TITLE
fix(cli): detect defaulted boolean flags in cliCommandWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.16.1] - 2026-07-31
+
+- Fix `scripts/utils/cliCommandWrapper.ts`: `unwrapSchemaIfNeeded` now also unwraps `ZodDefault` (recursively), so a boolean CLI flag declared as `z.boolean().default(false)` is registered as a boolean flag by `parseArgs` instead of a string option — previously `--flag` declared with a default was silently ignored. Only `ZodOptional`/`ZodNullable` were unwrapped before
+- Add spec coverage for `z.boolean().default(false)` (present → `true`, absent → `false`) in `scripts/utils/cliCommandWrapper.spec.ts`
+
 ## [1.16.0] - 2026-07-17
 
 - Support zod schemas with `.transform()`/`.pipe()` in `scripts/utils/cliCommandWrapper.ts`: `deriveParseArgsOptions` now resolves the flag-defining `ZodObject` through the input side of a `ZodPipe` (new `resolveInputObjectSchema` helper), so a CLI script can declare flat flags and transform them into a nested, schema-validated args object in a single `argsSchema` — command handlers receive the transformed output while `parseArgs` options (including repeatable/`multiple` flags) are still derived from the flat input shape

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-service-template",
-    "version": "1.16.0",
+    "version": "1.16.1",
     "devEngines": {
         "runtime": {
             "name": "node",

--- a/scripts/utils/cliCommandWrapper.spec.ts
+++ b/scripts/utils/cliCommandWrapper.spec.ts
@@ -62,6 +62,16 @@ describe('cliCommandWrapper', () => {
       expected: { flag: true },
     },
     {
+      inputArgs: ['--flag'],
+      schema: z.object({ flag: z.boolean().default(false) }),
+      expected: { flag: true },
+    },
+    {
+      inputArgs: [],
+      schema: z.object({ flag: z.boolean().default(false) }),
+      expected: { flag: false },
+    },
+    {
       inputArgs: ['--id=abc', '--id=def'],
       schema: z.object({ id: z.array(z.string()).optional() }),
       expected: { id: ['abc', 'def'] },

--- a/scripts/utils/cliCommandWrapper.ts
+++ b/scripts/utils/cliCommandWrapper.ts
@@ -13,8 +13,12 @@ import z from 'zod/v4'
 import { getApp } from '../../src/app.ts'
 import type { Dependencies } from '../../src/infrastructure/CommonModule.ts'
 
-const unwrapSchemaIfNeeded = (schema: z.Schema) =>
-  schema instanceof z.ZodOptional || schema instanceof z.ZodNullable ? schema.unwrap() : schema
+const unwrapSchemaIfNeeded = (schema: z.Schema): z.Schema =>
+  schema instanceof z.ZodOptional ||
+  schema instanceof z.ZodNullable ||
+  schema instanceof z.ZodDefault
+    ? unwrapSchemaIfNeeded(schema.unwrap())
+    : schema
 
 const resolveInputObjectSchema = (schema: z.Schema): z.ZodObject | undefined => {
   if (schema instanceof z.ZodObject) return schema

--- a/scripts/utils/cliCommandWrapper.ts
+++ b/scripts/utils/cliCommandWrapper.ts
@@ -17,7 +17,7 @@ const unwrapSchemaIfNeeded = (schema: z.Schema): z.Schema =>
   schema instanceof z.ZodOptional ||
   schema instanceof z.ZodNullable ||
   schema instanceof z.ZodDefault
-    ? unwrapSchemaIfNeeded(schema.unwrap())
+    ? unwrapSchemaIfNeeded(schema.unwrap() as z.Schema)
     : schema
 
 const resolveInputObjectSchema = (schema: z.Schema): z.ZodObject | undefined => {


### PR DESCRIPTION
## Changes

`scripts/utils/cliCommandWrapper.ts` — `unwrapSchemaIfNeeded` now also unwraps `ZodDefault` (recursively), so a boolean CLI flag declared as `z.boolean().default(false)` is registered as a boolean flag by `parseArgs` instead of a string option.

### Why
Previously only `ZodOptional` / `ZodNullable` were unwrapped. A boolean arg with a `.default()` fell through to `type: 'string'`, so `--flag` (passed with no value) was silently ignored — you couldn't declare a **defaulted boolean flag**. `.optional()` worked, but you lost the explicit default.

### Also
- Spec coverage for `z.boolean().default(false)` (present → `true`, absent → `false`).
- Bumped to `1.16.1` + CHANGELOG entry.