### PR TITLE
chore: Docker on Node 26, pnpm 11.23.0 without corepack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24.17, 26.x]
+        node-version: [24.x, 26.x]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: ci
 on:
   pull_request:
 
+# Least-privilege default for every job: `build` only needs to read the repo.
+# `automerge` opts into the write scopes it needs in its own `permissions` block.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Stop using corepack to provide pnpm in the image: the base stage now installs pnpm directly from npm at a version pinned by the `PNPM_VERSION` build arg (kept in sync with `package.json#devEngines.packageManager`), so the image ships exactly one explicit pnpm version and no longer depends on corepack, which is no longer bundled with Node
 - Bump pnpm from `11.22.0` to `11.23.0` (`devEngines.packageManager` plus the `@pnpm/exe` / `pnpm` package-manager dependencies in the lockfile)
 - Update the pnpm install instructions in [README.md](README.md) to install pnpm directly instead of enabling Corepack, and point at `devEngines.packageManager` instead of the long-removed `packageManager` field
+- CI: widen the Node matrix entry `24.17` to `24.x` and declare a workflow-level `permissions: contents: read` default, so the `build` job no longer inherits the repository/organization `GITHUB_TOKEN` defaults (the `automerge` job keeps its own `pull-requests: write` / `contents: write` block)
 
 ## [1.17.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.18.0] - 2026-08-24
+
+- Bump the Docker base image from `node:24.17.0-trixie-slim` to `node:26.7.0-trixie-slim` (Node 26 is already covered by the CI matrix; `devEngines.runtime` stays at `node >=24.16.0` so Node 24 remains supported for local development)
+- Stop using corepack to provide pnpm in the image: the base stage now installs pnpm directly from npm at a version pinned by the `PNPM_VERSION` build arg (kept in sync with `package.json#devEngines.packageManager`), so the image ships exactly one explicit pnpm version and no longer depends on corepack, which is no longer bundled with Node
+- Bump pnpm from `11.22.0` to `11.23.0` (`devEngines.packageManager` plus the `@pnpm/exe` / `pnpm` package-manager dependencies in the lockfile)
+- Update the pnpm install instructions in [README.md](README.md) to install pnpm directly instead of enabling Corepack, and point at `devEngines.packageManager` instead of the long-removed `packageManager` field
+
 ## [1.17.0] - 2026-08-21
 
 - Migrate all API contracts from the deprecated `buildRestContract` builder to `defineApiContract` (`@lokalise/api-contracts@8`), replacing `successResponseBodySchema`/`isEmptyResponseExpected` with `responsesByStatusCode` (using `noBodyResponse()` for `204`s) and adding the now-mandatory `summary` and `visibility` fields to every contract

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ---- Base Node ----
-FROM node:24.17.0-trixie-slim AS base
+FROM node:26.7.0-trixie-slim AS base
 
 RUN set -ex && \
     apt-get update && \
@@ -9,9 +9,13 @@ RUN set -ex && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Enable pnpm via corepack so the version pinned in package.json#packageManager
-# is used consistently across local, CI, and Docker builds.
-RUN corepack enable
+# pnpm is installed directly from npm rather than via corepack (which is no
+# longer bundled with Node 26), so the image ships one explicit, pinned pnpm
+# version. Keep in sync with package.json#devEngines.packageManager.
+ARG PNPM_VERSION=11.23.0
+RUN set -ex && \
+    npm install -g pnpm@${PNPM_VERSION} && \
+    npm cache clean --force
 
 # /pnpm hosts the pnpm store via a BuildKit cache mount in the deps stages
 # below; create it as node-owned so non-root installs can write to it.

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ are relevant for the technological stack of your organization, and replace `@lok
 
 1. Make sure your node version is compatible with the requirements in [package.json](package.json). We are working with `node >= 24` and recommend using a version manager, such as [nvm](https://github.com/nvm-sh/nvm), to manage multiple Node versions on your device if needed.
 
-2. Install [pnpm](https://pnpm.io/installation) (this project uses pnpm as its package manager — see the `packageManager` field in [package.json](package.json)). The easiest way on a recent Node.js is to enable Corepack:
+2. Install [pnpm](https://pnpm.io/installation) (this project uses pnpm as its package manager — the exact version is pinned in the `devEngines.packageManager` field of [package.json](package.json), and a mismatch hard-fails). Corepack is deliberately not used; install pnpm directly:
 
    ```shell
-   corepack enable
+   npm install -g pnpm@11.23.0
    ```
 
 3. Install all project dependencies:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-service-template",
-    "version": "1.17.0",
+    "version": "1.18.0",
     "devEngines": {
         "runtime": {
             "name": "node",
@@ -9,7 +9,7 @@
         },
         "packageManager": {
             "name": "pnpm",
-            "version": "11.22.0",
+            "version": "11.23.0",
             "onFail": "error"
         }
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,52 +7,52 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 11.22.0
-        version: 11.22.0
+        specifier: 11.23.0
+        version: 11.23.0
       pnpm:
-        specifier: 11.22.0
-        version: 11.22.0
+        specifier: 11.23.0
+        version: 11.23.0
 
 packages:
 
-  '@pnpm/exe@11.22.0':
-    resolution: {integrity: sha512-B1SGeKm+v9pX9YkzMmrnO2FbgBd8TDwzZ3jSj6J6ThxdyGvI4TsOfMeHARW4Wb25visPpmMDfIXrU76EZdJM4g==}
+  '@pnpm/exe@11.23.0':
+    resolution: {integrity: sha512-jBLtRlIloG7OdqEI4DCIQIIVrGMRlnMQxV+cq2BuBB8dhRVBHrNLHi1X2in1bI8Oa6xusPZtEWYgLwm8VkaNmQ==}
     hasBin: true
 
-  '@pnpm/linux-arm64@11.22.0':
-    resolution: {integrity: sha512-xzzn3jYG9QaiFZPaHcWM3yX4Fm9UGz5E42mzpbvUEvXYf5O9fwNolenOhGLpRl2qS5u35fjZSvDZbWlOwHMcug==}
+  '@pnpm/linux-arm64@11.23.0':
+    resolution: {integrity: sha512-IthFHf+6VvyfBJQXVPbYOhwexdrxD99uKJrPCd0i5igUI99c2QP85BnE0tLUZwes9eETBlE8gbCuXIIdhjFY6Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@pnpm/linux-x64@11.22.0':
-    resolution: {integrity: sha512-isvaPctGinbsM2hsTtRsMarN8Sr5QhXDTNmn8Xv9Lp1PjincCvH2RBbhpo+xYIOxzgls1dtQSdgoORUbfRVALQ==}
+  '@pnpm/linux-x64@11.23.0':
+    resolution: {integrity: sha512-DuxEM0gZqo/oq+OgJU09tYCGvoKow8xAntuqWVvH5+OQiiGU0raEJu7Gj/lsKj4Q5aPWG5vpUeN8S8ClbrtNwQ==}
     cpu: [x64]
     os: [linux]
 
-  '@pnpm/linuxstatic-arm64@11.22.0':
-    resolution: {integrity: sha512-i4J+AQWW0T3JBdXaLsvxu8ZmMG1HLS6JZQESdOR9uBv8Zumb4yg8GYT83eWRLacr6ngVdhEBiC3W4eOG64MFbA==}
+  '@pnpm/linuxstatic-arm64@11.23.0':
+    resolution: {integrity: sha512-d0lt2+zCtclW1URgeBZKEd8frAlBVvRgPxHq0ED4Zfrprm4wrilBi5enzZ5JtePVN7PSiPmj8wfpHRBzWBox2A==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/linuxstatic-x64@11.22.0':
-    resolution: {integrity: sha512-QYzk8jhSuSbVthW/OxEOhU3f3zhjpw4HqgedrlwbVNb7btCWn5del2Hb5PsYYka2PbmKq5EtF5IzYN8Yp1CfxQ==}
+  '@pnpm/linuxstatic-x64@11.23.0':
+    resolution: {integrity: sha512-MrQVTtzneSy9DSFr3FdOA7u+o2ci/YsAGnRQ7u/IuQTzvJpLv9d4u2orB1MjB9f2/Hqb3FyAdrAYBvPxss1Ldg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/macos-arm64@11.22.0':
-    resolution: {integrity: sha512-Io8Axk5kutPgMuAfOg1QGj3J0/KpLvH5iiPcmp7up8D4q7BNWT02ndQo3RyGWqrlkf5nwspM41GFpWTShrZ4Aw==}
+  '@pnpm/macos-arm64@11.23.0':
+    resolution: {integrity: sha512-sdMdxDAhtznQjGQxP9msVIiBm7R9J1yHw/oIdKJepLbG6UtLFASkZ/GlJNm+mxifTinsFplntrA4qigiVesfcw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/win-arm64@11.22.0':
-    resolution: {integrity: sha512-QgaRuKGQKov7xW2utPCgDT83fn/PU5cD6HFgib48oTslz7wv26E89d4jMCxL4GRmEL2YCfkYuj5ITj1oVWg5WQ==}
+  '@pnpm/win-arm64@11.23.0':
+    resolution: {integrity: sha512-d60y5JBlWmGJ2ve7Ob/P9TePSL1uPqW40r5k1i1MZeR28n6GUgIeeGlMAU6mb9ACP3i8BFbu3AnP7q3kpOYmPQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/win-x64@11.22.0':
-    resolution: {integrity: sha512-iWYsiSwpgxqur+TwsnSoPdOQaEfd4ygB84mb5tJUOgim6PHr1xhKJBndaQzH+At/WkLxLdYN+K8dYc4M7naezg==}
+  '@pnpm/win-x64@11.23.0':
+    resolution: {integrity: sha512-I4CY5dtaSfH2Ws1Ya8IB3cABqsJ+FS8yJgKG53bq1Ya2WMnB7rTR1LQcgyDoN0baEYD8kjXy1ehHikP11UBziw==}
     cpu: [x64]
     os: [win32]
 
@@ -116,45 +116,45 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  pnpm@11.22.0:
-    resolution: {integrity: sha512-H/hwxMYTPf2I+yr8Rt0T1H8JyXlLQ4xv20fKmMrzvBY4HuC+k6CRuOOCTPAfiJ9G19niCRD7C+GrD7W6qA3WIQ==}
+  pnpm@11.23.0:
+    resolution: {integrity: sha512-8ACC5bKDoZm3Tgedoo0VXACP4jL0TIoG6n3foBTs9xn8Ni95DsxnsoEG3awq+yTEmpoHkVnaVgss59Hpjv0Rrw==}
     engines: {node: '>=22.13'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe@11.22.0':
+  '@pnpm/exe@11.23.0':
     dependencies:
       '@reflink/reflink': 0.1.19
       detect-libc: 2.1.2
     optionalDependencies:
-      '@pnpm/linux-arm64': 11.22.0
-      '@pnpm/linux-x64': 11.22.0
-      '@pnpm/linuxstatic-arm64': 11.22.0
-      '@pnpm/linuxstatic-x64': 11.22.0
-      '@pnpm/macos-arm64': 11.22.0
-      '@pnpm/win-arm64': 11.22.0
-      '@pnpm/win-x64': 11.22.0
+      '@pnpm/linux-arm64': 11.23.0
+      '@pnpm/linux-x64': 11.23.0
+      '@pnpm/linuxstatic-arm64': 11.23.0
+      '@pnpm/linuxstatic-x64': 11.23.0
+      '@pnpm/macos-arm64': 11.23.0
+      '@pnpm/win-arm64': 11.23.0
+      '@pnpm/win-x64': 11.23.0
 
-  '@pnpm/linux-arm64@11.22.0':
+  '@pnpm/linux-arm64@11.23.0':
     optional: true
 
-  '@pnpm/linux-x64@11.22.0':
+  '@pnpm/linux-x64@11.23.0':
     optional: true
 
-  '@pnpm/linuxstatic-arm64@11.22.0':
+  '@pnpm/linuxstatic-arm64@11.23.0':
     optional: true
 
-  '@pnpm/linuxstatic-x64@11.22.0':
+  '@pnpm/linuxstatic-x64@11.23.0':
     optional: true
 
-  '@pnpm/macos-arm64@11.22.0':
+  '@pnpm/macos-arm64@11.23.0':
     optional: true
 
-  '@pnpm/win-arm64@11.22.0':
+  '@pnpm/win-arm64@11.23.0':
     optional: true
 
-  '@pnpm/win-x64@11.22.0':
+  '@pnpm/win-x64@11.23.0':
     optional: true
 
   '@reflink/reflink-darwin-arm64@0.1.19':
@@ -194,7 +194,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  pnpm@11.22.0: {}
+  pnpm@11.23.0: {}
 
 ---
 lockfileVersion: '9.0'


### PR DESCRIPTION
## What

- Bump the Docker base image from `node:24.17.0-trixie-slim` to the latest Node 26 slim image, `node:26.7.0-trixie-slim`.
- Replace `corepack enable` with a direct, pinned pnpm install (`npm install -g pnpm@${PNPM_VERSION}`, `PNPM_VERSION=11.23.0` build arg). Corepack is no longer bundled with the Node 26 images (`corepack: not found`), so the previous step would have broken the build outright — and the old comment referenced a `package.json#packageManager` field that was replaced by `devEngines` back in 1.15.0.
- Bump pnpm `11.22.0` → `11.23.0` (latest) in `devEngines.packageManager` and in the lockfile's `@pnpm/exe` / `pnpm` package-manager dependencies.
- README: install pnpm directly instead of enabling Corepack, and point at `devEngines.packageManager` instead of the removed `packageManager` field.
- CI: widen the matrix entry `24.17` → `24.x` (this was already sitting uncommitted in the working tree; it is Node-version related, so it rides along here).

`devEngines.runtime` intentionally stays at `node >=24.16.0` — CI still tests both 24.x and 26.x, so Node 24 remains supported for local development; only the shipped image moves to 26.

## Verification

- `docker build .` succeeds end to end on the new base image; the deps/build stages report `Done ... using pnpm v11.23.0`.
- The release image reports `node v26.7.0` / `pnpm 11.23.0`.
- `pnpm install --frozen-lockfile --ignore-scripts` passes against the regenerated lockfile (no drift, no other lockfile churn).
- `biome check` clean on the touched files.
