### PR TITLE
chore: migrate to lokalise errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.21.0] - 2026-09-02
+
+- Model errors with [`@lokalise/errors`](https://www.npmjs.com/package/@lokalise/errors) `2.0.0` instead of the `@lokalise/node-core` error classes. `UserService.getUser` now throws `UserNotFoundError` from [src/modules/users/errors/UserNotFoundError.ts](src/modules/users/errors/UserNotFoundError.ts), a `PublicError` bound to the `USER_NOT_FOUND` definition, so the response carries `code: 'USER_NOT_FOUND'` (plus the deprecated `errorCode` alias) and typed `details: { id }` in place of node-core's generic `ENTITY_NOT_FOUND`
+- Declare public error definitions in the `@node-service-template/api-contracts` workspace package ([packages/api-contracts/src/userErrors.ts](packages/api-contracts/src/userErrors.ts)) and reference them from `getUserContract` via `mergeErrorSchemasByStatusCode()`, so the `404` payload is part of the contract and of the generated OpenAPI spec. `@lokalise/errors` becomes a peer dependency of the contracts package
+- Add an `Error handling` section to [README.md](README.md) describing the layout, plus unit tests for the resolvers and an e2e test for the `404` response
+
 ## [1.20.0] - 2026-08-31
 
 - Migrate to zod 4.5 (`4.4.3` → `4.5.4`, root and the `@node-service-template/api-contracts` workspace package, whose `zod` peer range moves to `^4.5.4`) and put every runtime-parsed schema on the new ahead-of-time compiler via `z.compile()`: the API contract schemas in [packages/api-contracts/src/userSchemas.ts](packages/api-contracts/src/userSchemas.ts), the AMQP/SNS message schemas, the `UserImportJob` payload, the `FakeStoreApiClient` request/response schemas and the drizzle-derived row schemas in [src/db/schema](src/db/schema). `z.compile()` is typed as `<T>(schema: T) => T` and the returned clone keeps its `_zod.parent` link, so inference, `instanceof` checks and registry metadata written by `.describe()` all survive: the generated `openApiSpec.yaml` is byte-identical before and after the change

--- a/README.md
+++ b/README.md
@@ -178,6 +178,22 @@ The alternative is the global `import 'zod/compile'` side-effect import, which c
 constructed afterwards on first parse. This template uses explicit calls instead, so compilation does
 not depend on module evaluation order and behaves the same under vitest as it does in `src/server.ts`.
 
+### Error handling
+
+Errors are modelled with [`@lokalise/errors`](https://www.npmjs.com/package/@lokalise/errors).
+Client-facing errors are `PublicError` subclasses, internal ones `InternalError` subclasses. Every class
+carries a literal `code`, and public errors add an `ErrorType` that determines the HTTP status.
+
+- Public error definitions (`definePublicError()`) live in the
+  [api-contracts package](./packages/api-contracts/src/userErrors.ts), next to the contracts that
+  reference them via `mergeErrorSchemasByStatusCode()`. The error payload is therefore part of the
+  contract and generated OpenAPI spec, and clients can parse it with the same schema.
+- The owning module binds each definition to a class, e.g.
+  [UserNotFoundError.ts](./src/modules/users/errors/UserNotFoundError.ts), and throws it from its
+  services. Match errors with the static `isInstance()` guard, not `instanceof`.
+- The [global error handler](./src/infrastructure/errors/errorHandler.ts) turns a `PublicError` into
+  `error.httpStatusCode` plus `error.toPayload()`, and reports and logs anything mapped to a 5xx.
+
 ### OpenTelemetry instrumentation
 
 There is an OpenTelemetry integration included, using the gRPC exporter. See [environment variable configuration]() for the details on configuring it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-service-template",
-    "version": "1.20.0",
+    "version": "1.21.0",
     "devEngines": {
         "runtime": {
             "name": "node",
@@ -59,8 +59,9 @@
         "@lokalise/aws-config": "^9.0.0",
         "@lokalise/backend-http-client": "^12.2.0",
         "@lokalise/background-jobs-common": "^15.2.0",
+        "@lokalise/errors": "^2.0.0",
         "@lokalise/fastify-api-contracts": "^7.0.1",
-        "@lokalise/fastify-extras": "^31.6.0",
+        "@lokalise/fastify-extras": "^32.0.0",
         "@lokalise/healthcheck-utils": "^6.1.0",
         "@lokalise/node-core": "^14.9.1",
         "@lokalise/opentelemetry-fastify-bootstrap": "^4.1.1",

--- a/packages/api-contracts/package.json
+++ b/packages/api-contracts/package.json
@@ -20,11 +20,13 @@
     },
     "peerDependencies": {
         "@lokalise/api-contracts": "^8.0.0",
+        "@lokalise/errors": "^2.0.0",
         "@lokalise/zod-extras": "^3.0.2",
         "zod": "^4.5.4"
     },
     "devDependencies": {
         "@lokalise/api-contracts": "^8.0.0",
+        "@lokalise/errors": "^2.0.0",
         "@lokalise/tsconfig": "^5.0.0",
         "@lokalise/zod-extras": "^3.0.2",
         "typescript": "7.0.2",

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,2 +1,3 @@
 export * from './userApiContracts.ts'
+export * from './userErrors.ts'
 export * from './userSchemas.ts'

--- a/packages/api-contracts/src/userApiContracts.ts
+++ b/packages/api-contracts/src/userApiContracts.ts
@@ -1,4 +1,6 @@
 import { defineApiContract, noBodyResponse } from '@lokalise/api-contracts'
+import { mergeErrorSchemasByStatusCode } from '@lokalise/errors'
+import { USER_NOT_FOUND_ERROR_DEFINITION } from './userErrors.ts'
 import {
   AUTH_HEADERS,
   CREATE_USER_BODY_SCHEMA,
@@ -33,6 +35,7 @@ export const getUserContract = defineApiContract({
   pathResolver: (params) => `/users/${params.userId}`,
   responsesByStatusCode: {
     200: GET_USER_SCHEMA_RESPONSE_SCHEMA,
+    ...mergeErrorSchemasByStatusCode([USER_NOT_FOUND_ERROR_DEFINITION]),
   },
 })
 

--- a/packages/api-contracts/src/userErrors.ts
+++ b/packages/api-contracts/src/userErrors.ts
@@ -1,0 +1,12 @@
+import { definePublicError, ErrorType } from '@lokalise/errors'
+import z from 'zod/v4'
+
+// Public error definitions live next to the contracts so clients can parse error responses
+// with the same schemas the server uses to produce them (see `mergeErrorSchemasByStatusCode`
+// in userApiContracts.ts). The service binds each definition to an error class inside the
+// owning module, e.g. src/modules/users/errors/UserNotFoundError.ts.
+export const USER_NOT_FOUND_ERROR_DEFINITION = definePublicError({
+  code: 'USER_NOT_FOUND',
+  type: ErrorType.NOT_FOUND,
+  detailsSchema: z.object({ id: z.string() }),
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,19 +251,22 @@ importers:
         version: 8.0.0(zod@4.5.4)
       '@lokalise/aws-config':
         specifier: ^9.0.0
-        version: 9.0.0(1aa506678477158f4b62b953b293c606)
+        version: 9.0.0(f992c6a3be720319d151b6c5280d451f)
       '@lokalise/backend-http-client':
         specifier: ^12.2.0
         version: 12.2.0(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/node-core@14.9.1(zod@4.5.4))(zod@4.5.4)
       '@lokalise/background-jobs-common':
         specifier: ^15.2.0
         version: 15.2.0(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(toad-scheduler@4.1.0)(zod@4.5.4)
+      '@lokalise/errors':
+        specifier: ^2.0.0
+        version: 2.0.0(zod@4.5.4)
       '@lokalise/fastify-api-contracts':
         specifier: ^7.0.1
         version: 7.0.1(@fastify/sse@0.6.0(fastify@5.12.1))(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/node-core@14.9.1(zod@4.5.4))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@7.2.0))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(zod@4.5.4)
       '@lokalise/fastify-extras':
-        specifier: ^31.6.0
-        version: 31.6.0(@fastify/jwt@10.2.2)(@fastify/swagger@9.8.1(supports-color@7.2.0))(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/background-jobs-common@15.2.0(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(toad-scheduler@4.1.0)(zod@4.5.4))(@lokalise/node-core@14.9.1(zod@4.5.4))(@opentelemetry/api@1.9.1)(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(dd-trace@6.13.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@7.2.0))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(zod@4.5.4)
+        specifier: ^32.0.0
+        version: 32.0.0(@fastify/jwt@10.2.2)(@fastify/swagger@9.8.1(supports-color@7.2.0))(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/background-jobs-common@15.2.0(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(toad-scheduler@4.1.0)(zod@4.5.4))(@lokalise/errors@2.0.0(zod@4.5.4))(@lokalise/node-core@14.9.1(zod@4.5.4))(@opentelemetry/api@1.9.1)(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(dd-trace@6.13.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@7.2.0))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(zod@4.5.4)
       '@lokalise/healthcheck-utils':
         specifier: ^6.1.0
         version: 6.1.0(@lokalise/background-jobs-common@15.2.0(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(toad-scheduler@4.1.0)(zod@4.5.4))(ioredis@6.0.0(supports-color@7.2.0))(prom-client@15.1.3)(supports-color@7.2.0)(toad-scheduler@4.1.0)(zod@4.5.4)
@@ -467,6 +470,9 @@ importers:
       '@lokalise/api-contracts':
         specifier: ^8.0.0
         version: 8.0.0(zod@4.5.4)
+      '@lokalise/errors':
+        specifier: ^2.0.0
+        version: 2.0.0(zod@4.5.4)
       '@lokalise/tsconfig':
         specifier: ^5.0.0
         version: 5.0.0
@@ -1132,6 +1138,11 @@ packages:
     peerDependencies:
       '@lokalise/node-core': '>=11.0.0'
 
+  '@lokalise/errors@2.0.0':
+    resolution: {integrity: sha512-ohlCUm7f+/Ph9iD8q7f3QVZ479IB9d9VHNJrEUmeDlF3jWHS+odzOPGysjCmzJxKEQJSaLWLkZkq7RPijLnaYQ==}
+    peerDependencies:
+      zod: ^4.0.0
+
   '@lokalise/fastify-api-contracts@7.0.1':
     resolution: {integrity: sha512-Mx3lI7N7u08342KcyCuKqAtHSDrIxg+78YCFYVjFbtRnIbImQKpJD7C6aNGBVdG6mIPqNLKuiZeSM52wvjJXqQ==}
     peerDependencies:
@@ -1145,14 +1156,15 @@ packages:
       '@fastify/sse':
         optional: true
 
-  '@lokalise/fastify-extras@31.6.0':
-    resolution: {integrity: sha512-rSM8tGbsSR5+DeXyB9G37CdtLXPfsuDcwvPc1+iHJo9MnEripAht3JfMmYLwgz2Iqygg/0GAEcQ33J3plMOXnQ==}
+  '@lokalise/fastify-extras@32.0.0':
+    resolution: {integrity: sha512-McB13D336412JnJdR/JnEoCXKz+Uo/j1fZwjp5o7C1Drc7Sw+cTb2KbSHW7/QS4QZaRvaM3r6zp5YvTqCE0v7A==}
     engines: {node: '>=22'}
     peerDependencies:
       '@fastify/jwt': '>=9.1.0'
       '@fastify/swagger': '>=9.5.1'
       '@lokalise/api-contracts': '>=5.0.0'
       '@lokalise/background-jobs-common': '>=12.0.0'
+      '@lokalise/errors': '>=2.0.0'
       '@lokalise/node-core': '>=14.0.0'
       '@opentelemetry/api': '>=1.9.0'
       bullmq: ^5.19.0 || ^6.0.0
@@ -5308,12 +5320,12 @@ snapshots:
     dependencies:
       zod: 4.5.4
 
-  '@lokalise/aws-config@9.0.0(1aa506678477158f4b62b953b293c606)':
+  '@lokalise/aws-config@9.0.0(f992c6a3be720319d151b6c5280d451f)':
     dependencies:
       '@aws-sdk/client-sns': 3.1121.0
       '@aws-sdk/client-sqs': 3.1121.0
       '@aws-sdk/credential-providers': 3.1121.0
-      '@lokalise/fastify-extras': 31.6.0(@fastify/jwt@10.2.2)(@fastify/swagger@9.8.1(supports-color@7.2.0))(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/background-jobs-common@15.2.0(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(toad-scheduler@4.1.0)(zod@4.5.4))(@lokalise/node-core@14.9.1(zod@4.5.4))(@opentelemetry/api@1.9.1)(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(dd-trace@6.13.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@7.2.0))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(zod@4.5.4)
+      '@lokalise/fastify-extras': 32.0.0(@fastify/jwt@10.2.2)(@fastify/swagger@9.8.1(supports-color@7.2.0))(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/background-jobs-common@15.2.0(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(toad-scheduler@4.1.0)(zod@4.5.4))(@lokalise/errors@2.0.0(zod@4.5.4))(@lokalise/node-core@14.9.1(zod@4.5.4))(@opentelemetry/api@1.9.1)(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(dd-trace@6.13.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@7.2.0))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(zod@4.5.4)
       '@lokalise/node-core': 14.9.1(zod@4.5.4)
       '@lokalise/universal-ts-utils': 4.11.0
       '@message-queue-toolkit/core': 27.0.0(zod@4.5.4)
@@ -5351,6 +5363,10 @@ snapshots:
       '@bugsnag/js': 8.10.0
       '@lokalise/node-core': 14.9.1(zod@4.5.4)
 
+  '@lokalise/errors@2.0.0(zod@4.5.4)':
+    dependencies:
+      zod: 4.5.4
+
   '@lokalise/fastify-api-contracts@7.0.1(@fastify/sse@0.6.0(fastify@5.12.1))(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/node-core@14.9.1(zod@4.5.4))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@7.2.0))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(zod@4.5.4)':
     dependencies:
       '@lokalise/api-contracts': 8.0.0(zod@4.5.4)
@@ -5363,7 +5379,7 @@ snapshots:
     optionalDependencies:
       '@fastify/sse': 0.6.0(fastify@5.12.1)
 
-  '@lokalise/fastify-extras@31.6.0(@fastify/jwt@10.2.2)(@fastify/swagger@9.8.1(supports-color@7.2.0))(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/background-jobs-common@15.2.0(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(toad-scheduler@4.1.0)(zod@4.5.4))(@lokalise/node-core@14.9.1(zod@4.5.4))(@opentelemetry/api@1.9.1)(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(dd-trace@6.13.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@7.2.0))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(zod@4.5.4)':
+  '@lokalise/fastify-extras@32.0.0(@fastify/jwt@10.2.2)(@fastify/swagger@9.8.1(supports-color@7.2.0))(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/background-jobs-common@15.2.0(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(toad-scheduler@4.1.0)(zod@4.5.4))(@lokalise/errors@2.0.0(zod@4.5.4))(@lokalise/node-core@14.9.1(zod@4.5.4))(@opentelemetry/api@1.9.1)(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(dd-trace@6.13.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@7.2.0))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(zod@4.5.4)':
     dependencies:
       '@amplitude/analytics-node': 1.5.71
       '@bugsnag/js': 8.10.0
@@ -5374,6 +5390,7 @@ snapshots:
       '@lokalise/api-contracts': 8.0.0(zod@4.5.4)
       '@lokalise/background-jobs-common': 15.2.0(bullmq@6.3.2(ioredis@6.0.0(supports-color@7.2.0)))(ioredis@6.0.0(supports-color@7.2.0))(pino@10.3.1)(supports-color@7.2.0)(toad-scheduler@4.1.0)(zod@4.5.4)
       '@lokalise/error-utils': 3.0.0(@lokalise/node-core@14.9.1(zod@4.5.4))
+      '@lokalise/errors': 2.0.0(zod@4.5.4)
       '@lokalise/node-core': 14.9.1(zod@4.5.4)
       '@opentelemetry/api': 1.9.1
       '@scalar/fastify-api-reference': 1.67.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,30 +14,5 @@ allowBuilds:
   protobufjs: false
   tls-impersonate: false
 minimumReleaseAgeExclude:
-  - '@message-queue-toolkit/schemas@7.2.0'
-  - '@typescript/typescript-aix-ppc64@7.0.1-rc'
-  - '@typescript/typescript-darwin-arm64@7.0.1-rc'
-  - '@typescript/typescript-darwin-x64@7.0.1-rc'
-  - '@typescript/typescript-freebsd-arm64@7.0.1-rc'
-  - '@typescript/typescript-freebsd-x64@7.0.1-rc'
-  - '@typescript/typescript-linux-arm64@7.0.1-rc'
-  - '@typescript/typescript-linux-arm@7.0.1-rc'
-  - '@typescript/typescript-linux-loong64@7.0.1-rc'
-  - '@typescript/typescript-linux-mips64el@7.0.1-rc'
-  - '@typescript/typescript-linux-ppc64@7.0.1-rc'
-  - '@typescript/typescript-linux-riscv64@7.0.1-rc'
-  - '@typescript/typescript-linux-s390x@7.0.1-rc'
-  - '@typescript/typescript-linux-x64@7.0.1-rc'
-  - '@typescript/typescript-netbsd-arm64@7.0.1-rc'
-  - '@typescript/typescript-netbsd-x64@7.0.1-rc'
-  - '@typescript/typescript-openbsd-arm64@7.0.1-rc'
-  - '@typescript/typescript-openbsd-x64@7.0.1-rc'
-  - '@typescript/typescript-sunos-x64@7.0.1-rc'
-  - '@typescript/typescript-win32-arm64@7.0.1-rc'
-  - '@typescript/typescript-win32-x64@7.0.1-rc'
-  - layered-loader@14.4.1
-  - typescript@7.0.1-rc
-  - "@lokalise/*"
-  - "@message-queue-toolkit/*"
-  - "opinionated-machine"
-  - "@opinionated-machine/*"
+  - "@lokalise/errors"
+  - "@lokalise/fastify-extras"

--- a/src/modules/users/controllers/UserController.e2e.spec.ts
+++ b/src/modules/users/controllers/UserController.e2e.spec.ts
@@ -39,6 +39,7 @@ describe('UserController', () => {
       expect(response.statusCode).toBe(400)
       expect(response.json()).toMatchInlineSnapshot(`
         {
+          "code": "VALIDATION_ERROR",
           "details": {
             "error": [
               {
@@ -54,7 +55,6 @@ describe('UserController', () => {
               },
             ],
           },
-          "code": "VALIDATION_ERROR",
           "errorCode": "VALIDATION_ERROR",
           "message": "Invalid params",
         }

--- a/src/modules/users/controllers/UserController.e2e.spec.ts
+++ b/src/modules/users/controllers/UserController.e2e.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { describeApiContract } from '@lokalise/api-contracts'
 import { injectByApiContract } from '@lokalise/fastify-api-contracts'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
@@ -108,6 +109,28 @@ describe('UserController', () => {
       expect(response2.statusCode).toBe(200)
       expect(response1.json().data).toMatchObject(NEW_USER_FIXTURE)
       expect(response2.json().data).toMatchObject(NEW_USER_FIXTURE)
+    })
+
+    it('returns 404 with the contract error payload for an unknown user', async () => {
+      const token = generateTestJwt({ userId: '1' })
+      const unknownUserId = randomUUID()
+
+      const response = await injectByApiContract(app, UserController.contracts.getUser, {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+        pathParams: {
+          userId: unknownUserId,
+        },
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(response.json()).toEqual({
+        message: 'User not found',
+        code: 'USER_NOT_FOUND',
+        errorCode: 'USER_NOT_FOUND',
+        details: { id: unknownUserId },
+      })
     })
   })
 

--- a/src/modules/users/controllers/UserController.e2e.spec.ts
+++ b/src/modules/users/controllers/UserController.e2e.spec.ts
@@ -54,6 +54,7 @@ describe('UserController', () => {
               },
             ],
           },
+          "code": "VALIDATION_ERROR",
           "errorCode": "VALIDATION_ERROR",
           "message": "Invalid params",
         }

--- a/src/modules/users/errors/UserNotFoundError.ts
+++ b/src/modules/users/errors/UserNotFoundError.ts
@@ -1,0 +1,11 @@
+import { PublicError } from '@lokalise/errors'
+import { USER_NOT_FOUND_ERROR_DEFINITION } from '@node-service-template/api-contracts'
+
+// Binds the definition shared with the API contract, so HTTP status, error code and details
+// shape stay in sync with what clients parse. Match with `UserNotFoundError.isInstance(err)`,
+// not `instanceof`.
+export class UserNotFoundError extends PublicError.from(USER_NOT_FOUND_ERROR_DEFINITION) {
+  constructor(userId: string) {
+    super({ message: 'User not found', details: { id: userId } })
+  }
+}

--- a/src/modules/users/services/UserService.ts
+++ b/src/modules/users/services/UserService.ts
@@ -1,5 +1,4 @@
 import type { RequestContext } from '@lokalise/fastify-extras'
-import { EntityNotFoundError } from '@lokalise/node-core'
 import type {
   CREATE_USER_BODY_SCHEMA,
   UPDATE_USER_BODY_SCHEMA,
@@ -8,6 +7,7 @@ import type {
 import type { Loader } from 'layered-loader'
 import type z from 'zod/v4'
 import type { User } from '../../../db/schema/user.ts'
+import { UserNotFoundError } from '../errors/UserNotFoundError.ts'
 import type { UserRepository } from '../repositories/UserRepository.ts'
 import type { UsersInjectableDependencies } from '../UserModule.ts'
 
@@ -39,7 +39,7 @@ export class UserService {
       this.userLoader.getInMemoryOnly(userId.toString()) ?? (await this.userLoader.get(userId))
 
     if (!getUserResult) {
-      throw new EntityNotFoundError({ message: 'User not found', details: { id: userId } })
+      throw new UserNotFoundError(userId)
     }
 
     requestContext.logger.debug({ userId }, 'Resolved user')


### PR DESCRIPTION
## Summary

Migrate error handling from `@lokalise/node-core` to `@lokalise/errors`.

- Add contract-based `UserNotFoundError` with typed error details.
- Include the error in API contracts/OpenAPI and add e2e coverage.
- Bump `@lokalise/fastify-extras` to `^32.0.0`.
- Document the new error handling approach.